### PR TITLE
feat: 피드 상태 영속화, 네비게이션 개선 및 UI/UX 최적화

### DIFF
--- a/README.md
+++ b/README.md
@@ -569,6 +569,109 @@ Google Cloud Console 등에서 리다이렉트 URI에 Ngrok 주소 추가
 
 ---
 
+## 🚀 v2.6 주요 업데이트 (2026.01.23)
+
+### 1. 💚 피드 상태 영속화 (Like & Save Persistence)
+- **좋아요/저장 상태 백엔드 영속화:**
+  - LikedAppointment, SavedAppointment 엔티티 추가 (N:M 관계)
+  - 페이지 새로고침 후에도 상태 유지
+  - FeedResponse DTO에 `isLikedByMe`, `isSavedByMe` 필드 추가
+- **Optimistic Update 패턴:**
+  - 클릭 즉시 UI 업데이트
+  - API 실패 시 자동 롤백
+  - 사용자 경험 향상
+- **EscLikeButton 리팩토링:**
+  - Uncontrolled → Controlled Component
+  - 부모 컴포넌트에서 상태 관리
+  - 애니메이션 효과 유지 (💚 이모지)
+
+### 2. 🗄️ 저장한 일탈 페이지 구현
+- **SavedAppointments 페이지:**
+  - 저장한 약속 그리드 레이아웃
+  - 썸네일 이미지, 미션 제목, 장소명 표시
+  - 호버 시 삭제 버튼 표시
+  - 저장 취소 기능 (Optimistic Update)
+- **마이페이지 연동:**
+  - "저장한 일탈" 메뉴 항목 추가
+  - 카운트 및 안내 문구
+  - 빈 상태 처리
+
+### 3. 🧭 네비게이션 및 라우팅 대규모 개선
+- **MissionDetail BottomNav 표시:**
+  - MissionDetail을 MainLayout 내부로 이동
+  - 하단 네비게이션이 모든 페이지에서 일관되게 표시
+  - pb-24 추가로 콘텐츠 겹침 방지
+- **리스트 항목 클릭 버그 수정:**
+  - Appointments: `/chat/:id` → `/mission/:id` (잘못된 경로 수정)
+  - SavedAppointments: TODO 주석 → `/mission/:id` 네비게이션 구현
+  - 과거 약속 클릭 시 해당 약속의 상세 정보 정상 표시
+- **스마트 뒤로가기 버튼:**
+  - 하드코딩된 `/mypage` → `location.state?.from` 또는 `navigate(-1)`
+  - 브라우저 히스토리 활용
+  - 사용자가 온 경로로 정확히 복귀
+- **에러/완료 후 리다이렉트 개선:**
+  - 약속 완료/에러 시 `/mypage` → `/appointments`로 이동
+  - 더 직관적인 사용자 흐름
+
+### 4. 🛡️ Route Guards 개선
+- **RequireOnboarded 로직 수정:**
+  - 약속이 있는 사용자는 온보딩 완료 여부와 무관하게 피드/마이페이지 접근 허용
+  - 약속 보유자의 무한 리다이렉트 버그 해결
+- **GlobalRedirectWrapper 예외 경로 추가:**
+  - `/appointments`, `/reviews` 추가
+  - 사용자 경험 개선
+
+### 5. 🎨 UI/UX 최적화
+- **Debug Overlay 개선:**
+  - 토글 버튼(🛠️) 추가 (우측 상단 고정)
+  - localStorage로 표시/숨김 상태 저장
+  - 개발 환경에서만 활성화
+- **MainLayout 개선:**
+  - 상단 배너 제거 → FAB(Floating Action Button)로 대체
+  - 진행 중인 약속 알림 FAB (우측 하단)
+  - 티켓 아이콘 + 펄스 애니메이션
+  - Glow 효과 (네온 스타일)
+- **MissionDetail 스크롤 최적화:**
+  - 스크롤 방향 감지 (아래로 스크롤 시 버튼 숨김)
+  - Spring 애니메이션으로 부드러운 전환
+  - 콘텐츠 읽기에 집중
+- **D-Day 배지 디자인 개선:**
+  - 버튼처럼 보이지 않도록 수정
+  - `bg-electric-lime/20`, `text-electric-lime`
+  - `cursor-default`, `select-none`
+- **Appointments 다크 테마 적용:**
+  - 모든 색상을 네온 다크 테마로 통일
+  - 상태 배지, 필터 버튼, 로딩 스피너
+  - 일관된 브랜드 경험
+
+### 6. 🔧 기술적 개선
+- **RouteGuards 모듈화:**
+  - `frontend/src/routes/RouteGuards.tsx` 파일 분리
+  - RequireNewUser, RequireAppointment, RequireOnboarded, SmartRedirect
+  - 재사용 가능한 라우트 가드 컴포넌트
+- **Toast 시스템:**
+  - `frontend/src/utils/toast.ts` 유틸 추가
+  - 일관된 알림 메시지 표시
+- **타입 안전성 강화:**
+  - FeedItem 인터페이스에 `isLikedByMe`, `isSavedByMe` 추가
+  - 백엔드-프론트엔드 타입 동기화
+
+### 7. 🐛 주요 버그 수정
+- **버그 1: 리스트 항목 클릭 시 현재 약속 표시**
+  - 증상: 과거 약속 클릭 시 현재 진행 중인 약속이 표시됨
+  - 원인: URL 파라미터 무시, localStorage만 참조
+  - 해결: 리스트에서 올바른 ID를 URL에 전달하도록 수정
+- **버그 2: 약속 보유자 무한 리다이렉트**
+  - 증상: 약속이 있는데도 온보딩 페이지로 계속 이동
+  - 원인: RequireOnboarded가 온보딩 미완료 시 무조건 차단
+  - 해결: 약속 보유자는 온보딩 여부와 무관하게 접근 허용
+- **버그 3: 저장한 일탈 클릭 시 무반응**
+  - 증상: SavedAppointments에서 항목 클릭 시 아무 동작 없음
+  - 원인: TODO 주석만 있고 네비게이션 미구현
+  - 해결: `/mission/${item.appointmentId}` 네비게이션 구현
+
+---
+
 ## 🎯 다음 개발 계획 (Roadmap)
 
 ### Phase 1: 피드 기능 고도화

--- a/backend/src/main/java/com/littleescape/api/controller/AppointmentController.java
+++ b/backend/src/main/java/com/littleescape/api/controller/AppointmentController.java
@@ -97,12 +97,14 @@ public class AppointmentController {
 
     @GetMapping("/feed")
     public ResponseEntity<List<FeedResponse>> getPublicFeed(
+            @AuthenticationPrincipal String userId,
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "20") int size) {
 
-        log.info("공개 피드 조회 요청 - 페이지: {}, 사이즈: {}", page, size);
+        log.info("공개 피드 조회 요청 - 사용자: {}, 페이지: {}, 사이즈: {}", userId, page, size);
 
-        List<FeedResponse> feed = appointmentService.getPublicFeed(page, size);
+        Long userIdLong = userId != null ? Long.parseLong(userId) : null;
+        List<FeedResponse> feed = appointmentService.getPublicFeed(userIdLong, page, size);
 
         return ResponseEntity.ok(feed);
     }
@@ -221,6 +223,70 @@ public class AppointmentController {
         appointmentService.bulkDeleteAppointments(Long.parseLong(userId), appointmentIds);
 
         return ResponseEntity.ok().build();
+    }
+
+    /**
+     * 약속 저장/저장 취소 (토글 방식)
+     * 피드에서 마음에 드는 약속을 저장하여 추후 추천 가중치에 활용
+     */
+    @PostMapping("/{id}/save")
+    public ResponseEntity<java.util.Map<String, Object>> toggleSaveAppointment(
+            @AuthenticationPrincipal String userId,
+            @PathVariable Long id) {
+
+        if (userId == null) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+        }
+
+        log.info("약속 저장/취소 요청 - 사용자: {}, 약속 ID: {}", userId, id);
+
+        boolean isSaved = appointmentService.toggleSaveAppointment(Long.parseLong(userId), id);
+
+        return ResponseEntity.ok(java.util.Map.of(
+            "isSaved", isSaved,
+            "message", isSaved ? "저장되었습니다" : "저장 취소되었습니다"
+        ));
+    }
+
+    /**
+     * 약속 좋아요/좋아요 취소 (토글 방식)
+     * ESC 키보드 버튼으로 피드 게시물에 반응
+     */
+    @PostMapping("/{id}/like")
+    public ResponseEntity<java.util.Map<String, Object>> toggleLikeAppointment(
+            @AuthenticationPrincipal String userId,
+            @PathVariable Long id) {
+
+        if (userId == null) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+        }
+
+        log.info("약속 좋아요/취소 요청 - 사용자: {}, 약속 ID: {}", userId, id);
+
+        boolean isLiked = appointmentService.toggleLikeAppointment(Long.parseLong(userId), id);
+
+        return ResponseEntity.ok(java.util.Map.of(
+            "isLiked", isLiked,
+            "message", isLiked ? "좋아요!" : "좋아요 취소"
+        ));
+    }
+
+    /**
+     * 사용자가 저장한 약속 목록 조회
+     */
+    @GetMapping("/saved")
+    public ResponseEntity<List<FeedResponse>> getSavedAppointments(
+            @AuthenticationPrincipal String userId) {
+
+        if (userId == null) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+        }
+
+        log.info("저장한 약속 목록 조회 - 사용자: {}", userId);
+
+        List<FeedResponse> savedAppointments = appointmentService.getSavedAppointments(Long.parseLong(userId));
+
+        return ResponseEntity.ok(savedAppointments);
     }
 
     // ========================================

--- a/backend/src/main/java/com/littleescape/api/domain/LikedAppointment.java
+++ b/backend/src/main/java/com/littleescape/api/domain/LikedAppointment.java
@@ -1,0 +1,37 @@
+package com.littleescape.api.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+/**
+ * 사용자가 좋아요한 약속 (Like)
+ * N:M 관계를 풀어낸 중간 테이블
+ */
+@Entity
+@Table(
+    name = "liked_appointments",
+    uniqueConstraints = @UniqueConstraint(columnNames = {"user_id", "appointment_id"})
+)
+@Getter
+@Setter
+@NoArgsConstructor
+public class LikedAppointment extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "appointment_id", nullable = false)
+    private Appointment appointment;
+
+    // 편의 생성자
+    public LikedAppointment(User user, Appointment appointment) {
+        this.user = user;
+        this.appointment = appointment;
+    }
+}

--- a/backend/src/main/java/com/littleescape/api/domain/SavedAppointment.java
+++ b/backend/src/main/java/com/littleescape/api/domain/SavedAppointment.java
@@ -1,0 +1,38 @@
+package com.littleescape.api.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+/**
+ * 사용자가 저장한 약속 (Scrap/Bookmark)
+ * N:M 관계를 풀어낸 중간 테이블
+ * 추후 미션 추천 시 카테고리 가중치 계산에 활용
+ */
+@Entity
+@Table(
+    name = "saved_appointments",
+    uniqueConstraints = @UniqueConstraint(columnNames = {"user_id", "appointment_id"})
+)
+@Getter
+@Setter
+@NoArgsConstructor
+public class SavedAppointment extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "appointment_id", nullable = false)
+    private Appointment appointment;
+
+    // 편의 생성자
+    public SavedAppointment(User user, Appointment appointment) {
+        this.user = user;
+        this.appointment = appointment;
+    }
+}

--- a/backend/src/main/java/com/littleescape/api/dto/FeedResponse.java
+++ b/backend/src/main/java/com/littleescape/api/dto/FeedResponse.java
@@ -21,8 +21,14 @@ public class FeedResponse {
     private List<String> reviewKeywords;
     private AppointmentStatus status;  // ACCEPTED, ARRIVED, COMPLETED 등
     private LocalDateTime scheduledAt;
+    private Boolean isLikedByMe;  // 현재 사용자가 좋아요 했는지 여부
+    private Boolean isSavedByMe;  // 현재 사용자가 저장했는지 여부
 
     public static FeedResponse from(Appointment appointment) {
+        return from(appointment, null);
+    }
+
+    public static FeedResponse from(Appointment appointment, Long currentUserId) {
         // 사용자 닉네임 (익명 처리 옵션)
         String userNickname = appointment.getUser() != null
             ? maskNickname(appointment.getUser().getNickname())
@@ -48,7 +54,9 @@ public class FeedResponse {
             appointment.getCompletedAt(),
             appointment.getReviewKeywords(),
             appointment.getStatus(),
-            appointment.getScheduledAt()
+            appointment.getScheduledAt(),
+            false,  // isLikedByMe - will be set by service layer
+            false   // isSavedByMe - will be set by service layer
         );
     }
 

--- a/backend/src/main/java/com/littleescape/api/repository/LikedAppointmentRepository.java
+++ b/backend/src/main/java/com/littleescape/api/repository/LikedAppointmentRepository.java
@@ -1,0 +1,28 @@
+package com.littleescape.api.repository;
+
+import com.littleescape.api.domain.LikedAppointment;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface LikedAppointmentRepository extends JpaRepository<LikedAppointment, Long> {
+
+    // 특정 사용자와 약속의 좋아요 여부 확인
+    boolean existsByUserIdAndAppointmentId(Long userId, Long appointmentId);
+
+    // 특정 사용자와 약속의 좋아요 레코드 조회
+    Optional<LikedAppointment> findByUserIdAndAppointmentId(Long userId, Long appointmentId);
+
+    // 특정 사용자가 좋아요한 모든 약속 조회
+    List<LikedAppointment> findAllByUserIdOrderByCreatedAtDesc(Long userId);
+
+    // 좋아요 개수 조회
+    Long countByUserId(Long userId);
+
+    // 특정 약속의 좋아요 개수
+    Long countByAppointmentId(Long appointmentId);
+
+    // 사용자 삭제 시 좋아요 레코드도 함께 삭제
+    void deleteByUserId(Long userId);
+}

--- a/backend/src/main/java/com/littleescape/api/repository/SavedAppointmentRepository.java
+++ b/backend/src/main/java/com/littleescape/api/repository/SavedAppointmentRepository.java
@@ -1,0 +1,48 @@
+package com.littleescape.api.repository;
+
+import com.littleescape.api.domain.SavedAppointment;
+import com.littleescape.api.domain.type.MissionCategory;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+public interface SavedAppointmentRepository extends JpaRepository<SavedAppointment, Long> {
+
+    // 특정 사용자와 약속의 저장 여부 확인
+    boolean existsByUserIdAndAppointmentId(Long userId, Long appointmentId);
+
+    // 특정 사용자와 약속의 저장 레코드 조회
+    Optional<SavedAppointment> findByUserIdAndAppointmentId(Long userId, Long appointmentId);
+
+    // 특정 사용자가 저장한 모든 약속 조회 (최신순)
+    List<SavedAppointment> findAllByUserIdOrderByCreatedAtDesc(Long userId);
+
+    // 저장 개수 조회
+    Long countByUserId(Long userId);
+
+    /**
+     * 사용자가 저장한 약속들의 카테고리별 통계 조회
+     * 추천 알고리즘에서 가중치 계산에 사용
+     *
+     * @param userId 사용자 ID
+     * @return 카테고리별 저장 횟수 (Map<Category, Count>)
+     */
+    @Query("""
+        SELECT mt.category as category, COUNT(sa.id) as count
+        FROM SavedAppointment sa
+        JOIN sa.appointment a
+        JOIN a.missionTemplate mt
+        WHERE sa.user.id = :userId
+        GROUP BY mt.category
+        """)
+    List<Object[]> findCategoryStatsByUserId(@Param("userId") Long userId);
+
+    /**
+     * 사용자 삭제 시 저장 레코드도 함께 삭제
+     */
+    void deleteByUserId(Long userId);
+}

--- a/backend/src/main/java/com/littleescape/api/service/AppointmentService.java
+++ b/backend/src/main/java/com/littleescape/api/service/AppointmentService.java
@@ -38,11 +38,45 @@ public class AppointmentService {
     private final UserRepository userRepository;
     private final MissionTemplateRepository missionTemplateRepository;
     private final PlaceRepository placeRepository;
+    private final com.littleescape.api.repository.SavedAppointmentRepository savedAppointmentRepository;
+    private final com.littleescape.api.repository.LikedAppointmentRepository likedAppointmentRepository;
 
     // 1인 가구 타겟에 맞지 않는 키워드
     private static final String[] BAD_KEYWORDS = {
         "어린이", "유아", "강좌", "교실", "모집", "시니어", "동호회"
     };
+
+    /**
+     * 가중치 기반 미션 선택
+     * 사용자가 저장한 약속의 카테고리를 분석하여 선호 카테고리에 가중치 부여
+     *
+     * @param userId 사용자 ID
+     * @param candidates 미션 후보 리스트
+     * @return 선택된 미션
+     */
+    private MissionTemplate selectMissionWithCategoryWeight(Long userId, List<MissionTemplate> candidates) {
+        // 카테고리별 가중치 조회
+        java.util.Map<com.littleescape.api.domain.type.MissionCategory, Double> weights = getCategoryWeights(userId);
+
+        // 가중치 적용된 후보 리스트 생성
+        List<MissionTemplate> weightedCandidates = new ArrayList<>();
+        for (MissionTemplate mission : candidates) {
+            Double weight = weights.getOrDefault(mission.getCategory(), 1.0);
+
+            // 가중치만큼 리스트에 중복 추가 (예: 가중치 2.0이면 2번 추가)
+            int repeatCount = (int) Math.ceil(weight);
+            for (int i = 0; i < repeatCount; i++) {
+                weightedCandidates.add(mission);
+            }
+        }
+
+        log.info("가중치 적용 전 후보: {}개 → 적용 후: {}개",
+                candidates.size(), weightedCandidates.size());
+
+        // 가중치 적용된 리스트에서 랜덤 선택
+        Collections.shuffle(weightedCandidates);
+        return weightedCandidates.get(0);
+    }
 
     /**
      * 태그 충돌 검증 메서드
@@ -170,11 +204,11 @@ public class AppointmentService {
                 );
             }
 
-            // 2-4. 랜덤으로 하나 선정
-            Collections.shuffle(candidates);
-            selectedMission = candidates.get(0);
-            
-            log.info("자동 선정된 미션: {} (ID: {})", selectedMission.getTitle(), selectedMission.getId());
+            // 2-4. 가중치 기반 랜덤 선정 (저장한 약속 카테고리 우선)
+            selectedMission = selectMissionWithCategoryWeight(userId, candidates);
+
+            log.info("자동 선정된 미션: {} (ID: {}, 카테고리: {})",
+                    selectedMission.getTitle(), selectedMission.getId(), selectedMission.getCategory());
         }
 
         // 3. 선정된 미션을 Appointment에 연결
@@ -815,8 +849,13 @@ public class AppointmentService {
      */
     @Transactional(readOnly = true)
     public List<FeedResponse> getPublicFeed(int page, int size) {
+        return getPublicFeed(null, page, size);
+    }
+
+    @Transactional(readOnly = true)
+    public List<FeedResponse> getPublicFeed(Long userId, int page, int size) {
         log.info("=== 공개 피드 조회 시작 (생동감 모드) ===");
-        log.info("페이지: {}, 사이즈: {}", page, size);
+        log.info("페이지: {}, 사이즈: {}, 사용자: {}", page, size, userId);
 
         Pageable pageable = PageRequest.of(page, size);
 
@@ -837,7 +876,33 @@ public class AppointmentService {
 
         // 상태별 필터링 로직 제거 - 모든 상태 허용
         List<FeedResponse> feedResponses = appointments.stream()
-            .map(FeedResponse::from)
+            .map(appointment -> {
+                FeedResponse response = FeedResponse.from(appointment, userId);
+
+                // 사용자별 좋아요/저장 상태 설정
+                if (userId != null) {
+                    boolean isLiked = likedAppointmentRepository.existsByUserIdAndAppointmentId(userId, appointment.getId());
+                    boolean isSaved = savedAppointmentRepository.existsByUserIdAndAppointmentId(userId, appointment.getId());
+
+                    // Reflection을 사용하여 필드 설정 (DTO에 setter 추가 필요)
+                    return new FeedResponse(
+                        response.getAppointmentId(),
+                        response.getMissionTitle(),
+                        response.getPlaceName(),
+                        response.getProofImageUrls(),
+                        response.getProofComment(),
+                        response.getUserNickname(),
+                        response.getCompletedAt(),
+                        response.getReviewKeywords(),
+                        response.getStatus(),
+                        response.getScheduledAt(),
+                        isLiked,
+                        isSaved
+                    );
+                }
+
+                return response;
+            })
             .collect(Collectors.toList());
 
         log.info("피드 개수 (전체): {}", feedResponses.size());
@@ -1037,7 +1102,163 @@ public class AppointmentService {
         Appointment saved = appointmentRepository.save(appointment);
         
         log.warn("⚠️ [개발용] 약속 날짜 변경 완료: {} → {}, 상태: {}", appointmentId, now, saved.getStatus());
-        
+
         return saved;
+    }
+
+    // ========================================
+    // 저장 기능 (Scrap/Bookmark)
+    // ========================================
+
+    /**
+     * 약속 좋아요/좋아요 취소 (토글 방식)
+     * ESC 키보드 버튼으로 피드 게시물에 반응
+     *
+     * @param userId 사용자 ID
+     * @param appointmentId 좋아요할 약속 ID
+     * @return 좋아요 여부 (true: 좋아요됨, false: 좋아요 취소됨)
+     */
+    @Transactional
+    public boolean toggleLikeAppointment(Long userId, Long appointmentId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new RuntimeException("사용자를 찾을 수 없습니다."));
+
+        Appointment appointment = appointmentRepository.findById(appointmentId)
+                .orElseThrow(() -> new RuntimeException("약속을 찾을 수 없습니다."));
+
+        // 이미 좋아요되어 있는지 확인
+        java.util.Optional<com.littleescape.api.domain.LikedAppointment> existing =
+                likedAppointmentRepository.findByUserIdAndAppointmentId(userId, appointmentId);
+
+        if (existing.isPresent()) {
+            // 이미 좋아요되어 있으면 삭제 (좋아요 취소)
+            likedAppointmentRepository.delete(existing.get());
+            log.info("약속 좋아요 취소 - 사용자: {}, 약속: {}", userId, appointmentId);
+            return false;
+        } else {
+            // 좋아요되어 있지 않으면 새로 좋아요
+            com.littleescape.api.domain.LikedAppointment likedAppointment =
+                    new com.littleescape.api.domain.LikedAppointment(user, appointment);
+            likedAppointmentRepository.save(likedAppointment);
+            log.info("약속 좋아요 완료 - 사용자: {}, 약속: {}", userId, appointmentId);
+            return true;
+        }
+    }
+
+    /**
+     * 약속 저장/저장 취소 (토글 방식)
+     * 저장된 약속의 카테고리는 추후 추천 가중치 계산에 활용됨
+     *
+     * @param userId 사용자 ID
+     * @param appointmentId 저장할 약속 ID
+     * @return 저장 여부 (true: 저장됨, false: 저장 취소됨)
+     */
+    @Transactional
+    public boolean toggleSaveAppointment(Long userId, Long appointmentId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new RuntimeException("사용자를 찾을 수 없습니다."));
+
+        Appointment appointment = appointmentRepository.findById(appointmentId)
+                .orElseThrow(() -> new RuntimeException("약속을 찾을 수 없습니다."));
+
+        // 이미 저장되어 있는지 확인
+        java.util.Optional<com.littleescape.api.domain.SavedAppointment> existing =
+                savedAppointmentRepository.findByUserIdAndAppointmentId(userId, appointmentId);
+
+        if (existing.isPresent()) {
+            // 이미 저장되어 있으면 삭제 (저장 취소)
+            savedAppointmentRepository.delete(existing.get());
+            log.info("약속 저장 취소 - 사용자: {}, 약속: {}", userId, appointmentId);
+            return false;
+        } else {
+            // 저장되어 있지 않으면 새로 저장
+            com.littleescape.api.domain.SavedAppointment savedAppointment =
+                    new com.littleescape.api.domain.SavedAppointment(user, appointment);
+            savedAppointmentRepository.save(savedAppointment);
+            log.info("약속 저장 완료 - 사용자: {}, 약속: {}", userId, appointmentId);
+            return true;
+        }
+    }
+
+    /**
+     * 사용자가 저장한 약속 목록 조회
+     *
+     * @param userId 사용자 ID
+     * @return 저장된 약속 목록 (FeedResponse 형식)
+     */
+    @Transactional(readOnly = true)
+    public List<FeedResponse> getSavedAppointments(Long userId) {
+        List<com.littleescape.api.domain.SavedAppointment> savedAppointments =
+                savedAppointmentRepository.findAllByUserIdOrderByCreatedAtDesc(userId);
+
+        return savedAppointments.stream()
+                .map(sa -> {
+                    Appointment appointment = sa.getAppointment();
+                    FeedResponse response = FeedResponse.from(appointment, userId);
+
+                    // 저장된 목록이므로 isSavedByMe는 항상 true
+                    boolean isLiked = likedAppointmentRepository.existsByUserIdAndAppointmentId(userId, appointment.getId());
+
+                    return new FeedResponse(
+                        response.getAppointmentId(),
+                        response.getMissionTitle(),
+                        response.getPlaceName(),
+                        response.getProofImageUrls(),
+                        response.getProofComment(),
+                        response.getUserNickname(),
+                        response.getCompletedAt(),
+                        response.getReviewKeywords(),
+                        response.getStatus(),
+                        response.getScheduledAt(),
+                        isLiked,
+                        true  // isSavedByMe는 항상 true
+                    );
+                })
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * 사용자가 저장한 약속들의 카테고리별 가중치 계산
+     * 추천 알고리즘에서 활용
+     *
+     * @param userId 사용자 ID
+     * @return 카테고리별 가중치 맵 (예: {FOOD: 2.0, ACTIVITY: 1.5, ...})
+     */
+    @Transactional(readOnly = true)
+    public java.util.Map<com.littleescape.api.domain.type.MissionCategory, Double> getCategoryWeights(Long userId) {
+        List<Object[]> categoryStats = savedAppointmentRepository.findCategoryStatsByUserId(userId);
+
+        // 기본 가중치 (모든 카테고리 1.0)
+        java.util.Map<com.littleescape.api.domain.type.MissionCategory, Double> weights = new java.util.HashMap<>();
+        for (com.littleescape.api.domain.type.MissionCategory category : com.littleescape.api.domain.type.MissionCategory.values()) {
+            weights.put(category, 1.0);
+        }
+
+        if (categoryStats.isEmpty()) {
+            log.info("저장한 약속이 없어 기본 가중치 반환");
+            return weights;
+        }
+
+        // 총 저장 횟수 계산
+        long totalCount = categoryStats.stream()
+                .mapToLong(row -> (Long) row[1])
+                .sum();
+
+        // 카테고리별 가중치 계산 (비율 기반)
+        for (Object[] row : categoryStats) {
+            com.littleescape.api.domain.type.MissionCategory category =
+                    (com.littleescape.api.domain.type.MissionCategory) row[0];
+            Long count = (Long) row[1];
+
+            // 가중치 = 1.0 + (해당 카테고리 비율)
+            // 예: FOOD를 60% 저장했다면 가중치 1.6
+            double weight = 1.0 + ((double) count / totalCount);
+            weights.put(category, weight);
+
+            log.info("카테고리 가중치 계산 - {}: {}회 저장 ({}%), 가중치: {}",
+                    category, count, String.format("%.1f", (double) count / totalCount * 100), weight);
+        }
+
+        return weights;
     }
 }

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -86,7 +86,6 @@
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -473,7 +472,6 @@
       "resolved": "https://registry.npmjs.org/@capacitor/core/-/core-8.0.0.tgz",
       "integrity": "sha512-250HTVd/W/KdMygoqaedisvNbHbpbQTN2Hy/8ZYGm1nAqE0Fx7sGss4l0nDg33STxEdDhtVRoL2fIaaiukKseA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.1.0"
       }
@@ -1850,7 +1848,6 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.27.tgz",
       "integrity": "sha512-cisd7gxkzjBKU2GgdYrTdtQx1SORymWyaAFhaxQPK9bYO9ot3Y5OikQRvY0VYQtvwjeQnizCINJAenh/V7MK2w==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -1930,7 +1927,6 @@
       "integrity": "sha512-4Z+L8I2OqhZV8qA132M4wNL30ypZGYOQVBfMgxDH/K5UX0PNqTu1c6za9ST5r9+tavvHiTWmBnKzpCJ/GlVFtg==",
       "dev": true,
       "license": "BSD-2-Clause",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "7.18.0",
         "@typescript-eslint/types": "7.18.0",
@@ -2127,7 +2123,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2426,7 +2421,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -2950,7 +2944,6 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -3852,7 +3845,6 @@
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -4563,7 +4555,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -4781,7 +4772,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -4794,7 +4784,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -5433,7 +5422,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -5521,7 +5509,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -5616,7 +5603,6 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -5710,7 +5696,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,11 +1,14 @@
-import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom';
-import { ReactNode } from 'react';
+import { BrowserRouter, Routes, Route, Navigate, useLocation, useNavigate } from 'react-router-dom';
+import { ReactNode, useEffect } from 'react';
 
 // Layouts
 import MainLayout from './layouts/MainLayout';
 
 // Components
 import DebugOverlay from './components/DebugOverlay';
+
+// Route Guards
+import { RequireNewUser, RequireAppointment, RequireOnboarded, SmartRedirect } from './routes/RouteGuards';
 
 // Pages
 import FeedPage from './pages/FeedPage';
@@ -31,6 +34,7 @@ import MagicLogin from './pages/MagicLogin';
 import Onboarding from './pages/Onboarding';
 import ProfileEdit from './pages/ProfileEdit';
 import Contact from './pages/Contact';
+import SavedAppointments from './pages/SavedAppointments';
 
 // 보호된 라우트 컴포넌트
 const ProtectedRoute = ({ children }: { children: ReactNode }) => {
@@ -41,51 +45,51 @@ const ProtectedRoute = ({ children }: { children: ReactNode }) => {
   return <>{children}</>;
 };
 
-// 미션 라우트 가드 (약속 ID 검증)
-const MissionGuard = ({ children }: { children: ReactNode }) => {
-  const appointmentId = localStorage.getItem('appointmentId');
+/**
+ * 글로벌 리다이렉트 래퍼
+ * 앱 실행 시 사용자 상태를 체크하여 적절한 페이지로 리다이렉트
+ */
+const GlobalRedirectWrapper = ({ children }: { children: ReactNode }) => {
+  const location = useLocation();
+  const navigate = useNavigate();
 
-  // appointmentId가 없거나 유효하지 않으면 /feed로 리다이렉트
-  if (!appointmentId || appointmentId === 'null' || appointmentId === 'undefined') {
-    console.warn('⚠️ [MissionGuard] 유효하지 않은 약속 ID -> /feed로 리다이렉트');
-    return <Navigate to="/feed" replace />;
-  }
+  useEffect(() => {
+    const appointmentId = localStorage.getItem('appointmentId');
+    const onboardingComplete = localStorage.getItem('onboarding_complete');
+    const currentPath = location.pathname;
+
+    console.log('=== GlobalRedirectWrapper 체크 ===');
+    console.log('현재 경로:', currentPath);
+    console.log('약속 ID:', appointmentId);
+    console.log('온보딩 완료:', onboardingComplete === 'true');
+
+    // 예외 경로: 피드, 마이페이지, 약속 목록, 로그인 등은 체크 안 함
+    const exemptPaths = ['/feed', '/mypage', '/appointments', '/reviews', '/login', '/oauth/callback', '/auth/callback', '/magic-login', '/dev-console', '/profile-edit', '/contact', '/mypage/saved'];
+    if (exemptPaths.some(path => currentPath.startsWith(path))) {
+      console.log('✅ 예외 경로 - 리다이렉트 skip');
+      return;
+    }
+
+    // 1순위: 약속 있음 -> 온보딩이나 다른 곳에 있으면 미션으로 납치
+    if (appointmentId && appointmentId !== 'null' && appointmentId !== 'undefined') {
+      if (currentPath.startsWith('/chat') || currentPath.startsWith('/onboarding') || currentPath === '/location' || currentPath === '/time-picker') {
+        console.log('🎯 약속 있는데 온보딩 접근 시도 -> /mission으로 납치!');
+        navigate(`/mission/${appointmentId}`, { replace: true });
+        return;
+      }
+    }
+
+    // 2순위: 가입 완료 -> 온보딩 접근 시 피드로 튕김
+    if (onboardingComplete === 'true') {
+      if (currentPath.startsWith('/chat') || currentPath.startsWith('/onboarding')) {
+        console.log('⚠️ 이미 가입한 유저가 온보딩 접근 -> /feed로 튕김!');
+        navigate('/feed', { replace: true });
+        return;
+      }
+    }
+  }, [location.pathname, navigate]);
 
   return <>{children}</>;
-};
-
-// 랜딩 페이지 가드 (자동 로그인 체크)
-const LandingGuard = () => {
-  const token = localStorage.getItem('token');
-  const onboardingComplete = localStorage.getItem('onboarding_complete');
-  const userLocation = localStorage.getItem('user_location');
-
-  console.log('=== LandingGuard 체크 ===');
-  console.log('토큰 존재:', !!token);
-  console.log('온보딩 완료:', onboardingComplete === 'true');
-  console.log('위치 설정:', !!userLocation);
-
-  // 1. 토큰 없음 -> 로그인 페이지로 이동
-  if (!token || token === 'null' || token === 'undefined') {
-    console.log('🚫 토큰 없음 -> 로그인 페이지로 이동');
-    return <Navigate to="/login" replace />;
-  }
-
-  // 2. 토큰 있음 + 온보딩 미완료 -> 온보딩 채팅으로 이동
-  if (onboardingComplete !== 'true') {
-    console.log('📝 온보딩 미완료 -> 채팅 온보딩으로 이동');
-    return <Navigate to="/chat" replace />;
-  }
-
-  // 3. 토큰 있음 + 온보딩 완료 + 위치 미설정 -> 위치 설정 페이지로 이동
-  if (!userLocation) {
-    console.log('📍 위치 미설정 -> 위치 설정 페이지로 이동');
-    return <Navigate to="/location" replace />;
-  }
-
-  // 4. 토큰 있음 + 온보딩 완료 + 위치 설정 완료 -> 피드 페이지로 이동 (자동 로그인)
-  console.log('✅ 자동 로그인 성공 -> 피드 페이지로 이동');
-  return <Navigate to="/feed" replace />;
 };
 
 function App() {
@@ -94,7 +98,8 @@ function App() {
       {/* Debug Overlay - 개발 모드 전용 */}
       <DebugOverlay />
 
-      <Routes>
+      <GlobalRedirectWrapper>
+        <Routes>
         {/* Public Routes */}
         <Route path="/login" element={<LoginPage />} />
         <Route path="/oauth/callback" element={<OAuthCallback />} />
@@ -111,11 +116,11 @@ function App() {
           }
         />
 
-        {/* Main Entry Point - Landing Guard (자동 로그인 체크) */}
+        {/* Main Entry Point - Smart Redirect */}
         <Route
           index
           path="/"
-          element={<LandingGuard />}
+          element={<SmartRedirect />}
         />
 
         {/* Location Setting Route */}
@@ -138,53 +143,75 @@ function App() {
           }
         />
 
-        {/* Missions Route - Without Bottom Navigation (Full Screen) */}
+        {/* Missions Route - Without Bottom Navigation (Full Screen) - 약속 필수 */}
         <Route
           path="/missions"
           element={
             <ProtectedRoute>
-              <MissionGuard>
+              <RequireAppointment>
                 <MissionList />
-              </MissionGuard>
+              </RequireAppointment>
             </ProtectedRoute>
           }
         />
 
-        {/* Main App - With Bottom Navigation */}
-        <Route element={<ProtectedRoute><MainLayout /></ProtectedRoute>}>
+        {/* Main App - With Bottom Navigation (온보딩 완료 필수) */}
+        <Route element={
+          <ProtectedRoute>
+            <RequireOnboarded>
+              <MainLayout />
+            </RequireOnboarded>
+          </ProtectedRoute>
+        }>
           {/* Bottom Nav Routes */}
           <Route index path="feed" element={<FeedPage />} />
           <Route path="reviews" element={<Reviews />} />
           <Route path="appointments" element={<Appointments />} />
           <Route path="mypage" element={<MyPage />} />
+
+          {/* Mission Detail - Now with Bottom Nav */}
+          <Route
+            path="mission/:appointmentId"
+            element={
+              <RequireAppointment>
+                <MissionDetail />
+              </RequireAppointment>
+            }
+          />
         </Route>
 
-        {/* Chat Routes - Without Bottom Navigation */}
+        {/* Chat Routes - Without Bottom Navigation (뉴비 전용) */}
         <Route
           path="/chat/:id"
           element={
             <ProtectedRoute>
-              <ChatAppointment />
+              <RequireNewUser>
+                <ChatAppointment />
+              </RequireNewUser>
             </ProtectedRoute>
           }
         />
-        
-        {/* Dev: 온보딩 채팅 (파라미터 없이 직접 접근) */}
+
+        {/* Dev: 온보딩 채팅 (파라미터 없이 직접 접근) - 뉴비 전용 */}
         <Route
           path="/chat"
           element={
             <ProtectedRoute>
-              <ChatAppointment />
+              <RequireNewUser>
+                <ChatAppointment />
+              </RequireNewUser>
             </ProtectedRoute>
           }
         />
-        
-        {/* Dev: 온보딩 채팅 (Alias) */}
+
+        {/* Dev: 온보딩 채팅 (Alias) - 뉴비 전용 */}
         <Route
           path="/appointment"
           element={
             <ProtectedRoute>
-              <ChatAppointment />
+              <RequireNewUser>
+                <ChatAppointment />
+              </RequireNewUser>
             </ProtectedRoute>
           }
         />
@@ -206,28 +233,26 @@ function App() {
             </ProtectedRoute>
           }
         />
+        <Route
+          path="/mypage/saved"
+          element={
+            <ProtectedRoute>
+              <SavedAppointments />
+            </ProtectedRoute>
+          }
+        />
 
         {/* Dev Tools - God Mode Simulation */}
         <Route path="/dev-console" element={<DevConsole />} />
 
-        {/* Legacy Routes - 호환성 유지 */}
+        {/* Legacy Routes - 호환성 유지 (약속 필수) */}
         <Route
           path="/pick-mission/:appointmentId"
           element={
             <ProtectedRoute>
-              <MissionGuard>
+              <RequireAppointment>
                 <PickMission />
-              </MissionGuard>
-            </ProtectedRoute>
-          }
-        />
-        <Route
-          path="/mission/:appointmentId"
-          element={
-            <ProtectedRoute>
-              <MissionGuard>
-                <MissionDetail />
-              </MissionGuard>
+              </RequireAppointment>
             </ProtectedRoute>
           }
         />
@@ -235,13 +260,14 @@ function App() {
           path="/mission-proof/:appointmentId"
           element={
             <ProtectedRoute>
-              <MissionGuard>
+              <RequireAppointment>
                 <MissionProof />
-              </MissionGuard>
+              </RequireAppointment>
             </ProtectedRoute>
           }
         />
-      </Routes>
+        </Routes>
+      </GlobalRedirectWrapper>
     </BrowserRouter>
   );
 }

--- a/frontend/src/api/appointmentApi.ts
+++ b/frontend/src/api/appointmentApi.ts
@@ -70,6 +70,8 @@ export interface FeedItem {
   reviewKeywords: string[];
   status: string; // ACCEPTED, ARRIVED, COMPLETED 등
   scheduledAt: string;
+  isLikedByMe: boolean; // 현재 사용자가 좋아요 했는지 여부
+  isSavedByMe: boolean; // 현재 사용자가 저장했는지 여부
 }
 
 export async function getPublicFeed(page: number = 0, size: number = 20): Promise<FeedItem[]> {
@@ -227,18 +229,18 @@ export async function swapMission(appointmentId: number): Promise<Appointment> {
 export async function getNextAppointment(): Promise<Appointment | null> {
   try {
     const appointments = await getMyAppointments();
-    
+
     console.log('📋 전체 약속 목록:', appointments);
     console.log('📋 약속 개수:', appointments.length);
 
     // 완료되지 않은 약속만 필터링 (PENDING, ACCEPTED 포함)
     const activeAppointments = appointments.filter(
-      (apt) => apt.status !== 'COMPLETED' && 
-               apt.status !== 'CANCELLED' && 
+      (apt) => apt.status !== 'COMPLETED' &&
+               apt.status !== 'CANCELLED' &&
                apt.status !== 'NO_SHOW' &&
                apt.status !== 'REJECTED'
     );
-    
+
     console.log('🔄 진행 중인 약속:', activeAppointments);
     console.log('🔄 진행 중인 약속 개수:', activeAppointments.length);
 
@@ -251,7 +253,7 @@ export async function getNextAppointment(): Promise<Appointment | null> {
     const sorted = activeAppointments.sort((a, b) =>
       new Date(a.scheduledAt).getTime() - new Date(b.scheduledAt).getTime()
     );
-    
+
     console.log('✅ 가장 가까운 약속:', sorted[0]);
     console.log('  - ID:', sorted[0].id);
     console.log('  - Status:', sorted[0].status);
@@ -263,4 +265,46 @@ export async function getNextAppointment(): Promise<Appointment | null> {
     console.error('❌ 다음 약속 조회 실패:', error);
     return null;
   }
+}
+
+// ========================================
+// 저장 기능 (Scrap/Bookmark)
+// ========================================
+
+/**
+ * 약속 좋아요/좋아요 취소 (토글)
+ * @param appointmentId 좋아요할 약속 ID
+ * @returns 좋아요 여부 (true: 좋아요됨, false: 좋아요 취소됨)
+ */
+export async function toggleLikeAppointment(appointmentId: number): Promise<boolean> {
+  const response = await apiFetch<{ isLiked: boolean; message: string }>(
+    `/api/v1/appointments/${appointmentId}/like`,
+    {
+      method: 'POST',
+    }
+  );
+  return response.isLiked;
+}
+
+/**
+ * 약속 저장/저장 취소 (토글)
+ * @param appointmentId 저장할 약속 ID
+ * @returns 저장 여부 (true: 저장됨, false: 저장 취소됨)
+ */
+export async function toggleSaveAppointment(appointmentId: number): Promise<boolean> {
+  const response = await apiFetch<{ isSaved: boolean; message: string }>(
+    `/api/v1/appointments/${appointmentId}/save`,
+    {
+      method: 'POST',
+    }
+  );
+  return response.isSaved;
+}
+
+/**
+ * 사용자가 저장한 약속 목록 조회
+ * @returns 저장된 약속 리스트
+ */
+export async function getSavedAppointments(): Promise<FeedItem[]> {
+  return apiFetch<FeedItem[]>('/api/v1/appointments/saved');
 }

--- a/frontend/src/components/DebugOverlay.tsx
+++ b/frontend/src/components/DebugOverlay.tsx
@@ -10,6 +10,11 @@ const DebugOverlay = () => {
   const location = useLocation();
   const navigate = useNavigate();
 
+  const [isVisible, setIsVisible] = useState(() => {
+    const saved = localStorage.getItem('debug_overlay_visible');
+    return saved === null ? true : saved === 'true';
+  });
+
   const [localStorageData, setLocalStorageData] = useState({
     onboarding_complete: '',
     user_location: '',
@@ -18,6 +23,13 @@ const DebugOverlay = () => {
 
   const [appointmentStatus, setAppointmentStatus] = useState<string>('N/A');
   const [isLoading, setIsLoading] = useState(false);
+
+  // 가시성 토글
+  const toggleVisibility = () => {
+    const newVisibility = !isVisible;
+    setIsVisible(newVisibility);
+    localStorage.setItem('debug_overlay_visible', String(newVisibility));
+  };
 
   // 로컬 스토리지 실시간 업데이트
   const refreshLocalStorage = () => {
@@ -90,11 +102,24 @@ const DebugOverlay = () => {
   };
 
   return (
-    <div
-      className="fixed top-0 right-0 z-[9999] bg-black/80 text-white text-xs p-3 max-w-sm border-l border-b border-gray-600 shadow-lg"
-      style={{ fontFamily: 'monospace' }}
-    >
-      <div className="font-bold text-sm mb-2 text-yellow-400">🛠️ DEBUG OVERLAY</div>
+    <>
+      {/* 토글 버튼 (항상 보임) */}
+      <button
+        onClick={toggleVisibility}
+        className="fixed top-4 right-4 z-[10000] bg-yellow-500 hover:bg-yellow-600 text-black font-bold px-3 py-2 rounded-lg shadow-lg transition"
+        style={{ fontFamily: 'monospace' }}
+        title={isVisible ? 'Debug Overlay 숨기기' : 'Debug Overlay 보기'}
+      >
+        🛠️
+      </button>
+
+      {/* 디버그 오버레이 */}
+      {isVisible && (
+        <div
+          className="fixed top-16 right-4 z-[9999] bg-black/90 text-white text-xs p-3 max-w-sm border border-gray-600 rounded-lg shadow-lg"
+          style={{ fontFamily: 'monospace' }}
+        >
+          <div className="font-bold text-sm mb-2 text-yellow-400">🛠️ DEBUG OVERLAY</div>
 
       {/* 현재 경로 */}
       <div className="mb-2">
@@ -165,7 +190,9 @@ const DebugOverlay = () => {
           [Go Home] 피드로 이동
         </button>
       </div>
-    </div>
+        </div>
+      )}
+    </>
   );
 };
 

--- a/frontend/src/components/EscLikeButton.tsx
+++ b/frontend/src/components/EscLikeButton.tsx
@@ -1,0 +1,80 @@
+import { useState } from 'react';
+import { motion } from 'framer-motion';
+
+interface EscLikeButtonProps {
+  isLiked: boolean;
+  onLike: () => void;
+}
+
+const EscLikeButton = ({
+  isLiked,
+  onLike
+}: EscLikeButtonProps) => {
+  const [isAnimating, setIsAnimating] = useState(false);
+
+  const handleClick = () => {
+    setIsAnimating(true);
+
+    // 애니메이션 완료 후 플래그 리셋
+    setTimeout(() => setIsAnimating(false), 600);
+
+    // 콜백 실행
+    onLike();
+  };
+
+  return (
+    <motion.button
+      onClick={handleClick}
+      whileTap={{ scale: 0.9 }}
+      className={`relative group ${isLiked ? 'keycap-liked' : 'keycap-default'}`}
+    >
+      {/* 키캡 본체 */}
+      <div
+        className={`
+          relative px-4 py-2 rounded-lg font-bold text-xs tracking-wider
+          transition-all duration-300 transform
+          ${isLiked
+            ? 'bg-gradient-to-br from-electric-lime to-neon-purple text-deep-charcoal shadow-lg shadow-electric-lime/50'
+            : 'bg-charcoal-lighter text-text-gray shadow-md border border-charcoal-lighter hover:border-electric-lime/30'
+          }
+          ${isLiked ? 'translate-y-0' : 'translate-y-[-2px]'}
+          group-hover:translate-y-0
+        `}
+        style={{
+          boxShadow: isLiked
+            ? '0 0 20px rgba(204, 255, 0, 0.5), inset 0 -2px 4px rgba(0,0,0,0.2)'
+            : 'inset 0 -3px 0 rgba(0,0,0,0.3), 0 2px 4px rgba(0,0,0,0.3)',
+        }}
+      >
+        <span className="drop-shadow-sm">ESC</span>
+      </div>
+
+      {/* 키캡 그림자/베이스 */}
+      <div
+        className={`
+          absolute inset-0 rounded-lg -z-10 transition-all duration-300
+          ${isLiked
+            ? 'bg-electric-lime/20 blur-sm'
+            : 'bg-deep-charcoal/50'
+          }
+          ${isLiked ? 'translate-y-1' : 'translate-y-0'}
+          group-hover:translate-y-1
+        `}
+      />
+
+      {/* 좋아요 애니메이션 */}
+      {isAnimating && (
+        <motion.div
+          initial={{ scale: 1.5, y: -10, opacity: 1 }}
+          animate={{ scale: 1, y: -30, opacity: 0 }}
+          transition={{ duration: 0.6 }}
+          className="absolute top-0 left-1/2 transform -translate-x-1/2 text-electric-lime text-xl"
+        >
+          💚
+        </motion.div>
+      )}
+    </motion.button>
+  );
+};
+
+export default EscLikeButton;

--- a/frontend/src/components/ScrollToTopButton.tsx
+++ b/frontend/src/components/ScrollToTopButton.tsx
@@ -1,0 +1,65 @@
+import { useState, useEffect } from 'react';
+import { motion, AnimatePresence } from 'framer-motion';
+import { ArrowUp } from 'lucide-react';
+
+interface ScrollToTopButtonProps {
+  threshold?: number; // 스크롤이 몇 px 이상일 때 버튼을 표시할지
+}
+
+const ScrollToTopButton = ({ threshold = 300 }: ScrollToTopButtonProps) => {
+  const [isVisible, setIsVisible] = useState(false);
+
+  useEffect(() => {
+    const toggleVisibility = () => {
+      if (window.scrollY > threshold) {
+        setIsVisible(true);
+      } else {
+        setIsVisible(false);
+      }
+    };
+
+    window.addEventListener('scroll', toggleVisibility);
+
+    return () => {
+      window.removeEventListener('scroll', toggleVisibility);
+    };
+  }, [threshold]);
+
+  const scrollToTop = () => {
+    window.scrollTo({
+      top: 0,
+      behavior: 'smooth',
+    });
+  };
+
+  return (
+    <AnimatePresence>
+      {isVisible && (
+        <motion.button
+          initial={{ opacity: 0, scale: 0.8, y: 20 }}
+          animate={{ opacity: 1, scale: 1, y: 0 }}
+          exit={{ opacity: 0, scale: 0.8, y: 20 }}
+          transition={{ type: 'spring', stiffness: 300, damping: 20 }}
+          onClick={scrollToTop}
+          className="
+            fixed bottom-28 right-6 z-40
+            w-14 h-14 rounded-full
+            bg-electric-lime text-deep-charcoal
+            flex items-center justify-center
+            shadow-lg shadow-electric-lime/30
+            hover:shadow-xl hover:shadow-electric-lime/50
+            hover:scale-110
+            active:scale-95
+            transition-all duration-200
+          "
+          whileHover={{ scale: 1.1 }}
+          whileTap={{ scale: 0.95 }}
+        >
+          <ArrowUp size={24} strokeWidth={3} />
+        </motion.button>
+      )}
+    </AnimatePresence>
+  );
+};
+
+export default ScrollToTopButton;

--- a/frontend/src/hooks/useInfiniteScroll.ts
+++ b/frontend/src/hooks/useInfiniteScroll.ts
@@ -1,0 +1,53 @@
+import { useEffect, useRef, RefObject } from 'react';
+
+interface UseInfiniteScrollProps {
+  onLoadMore: () => void;
+  hasMore: boolean;
+  loading: boolean;
+  threshold?: number;
+}
+
+/**
+ * IntersectionObserver를 사용한 무한 스크롤 훅
+ * @param onLoadMore - 더 많은 데이터를 로드하는 콜백 함수
+ * @param hasMore - 더 많은 데이터가 있는지 여부
+ * @param loading - 현재 로딩 중인지 여부
+ * @param threshold - 관찰 요소가 몇 %만큼 보일 때 트리거할지 (0.0 ~ 1.0)
+ * @returns 마지막 요소에 연결할 ref
+ */
+export const useInfiniteScroll = ({
+  onLoadMore,
+  hasMore,
+  loading,
+  threshold = 0.5,
+}: UseInfiniteScrollProps): RefObject<HTMLDivElement> => {
+  const observerTarget = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const target = observerTarget.current;
+    if (!target) return;
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        // 타겟이 화면에 보이고, 로딩 중이 아니며, 더 많은 데이터가 있을 때
+        if (entries[0].isIntersecting && !loading && hasMore) {
+          onLoadMore();
+        }
+      },
+      {
+        threshold,
+        rootMargin: '100px', // 100px 전에 미리 로드
+      }
+    );
+
+    observer.observe(target);
+
+    return () => {
+      if (target) {
+        observer.unobserve(target);
+      }
+    };
+  }, [onLoadMore, hasMore, loading, threshold]);
+
+  return observerTarget;
+};

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -154,4 +154,20 @@
     @apply bg-text-gray hover:bg-electric-lime rounded-solotion-sm;
     transition: background-color 0.2s;
   }
+
+  /* Toast animation */
+  @keyframes slide-up {
+    from {
+      opacity: 0;
+      transform: translate(-50%, 20px);
+    }
+    to {
+      opacity: 1;
+      transform: translate(-50%, 0);
+    }
+  }
+
+  .animate-slide-up {
+    animation: slide-up 0.3s ease-out;
+  }
 }

--- a/frontend/src/layouts/MainLayout.tsx
+++ b/frontend/src/layouts/MainLayout.tsx
@@ -1,31 +1,47 @@
 import { Outlet, useNavigate, useLocation } from 'react-router-dom';
 import { useNextAppointment } from '../hooks/useNextAppointment';
+import { useState, useEffect } from 'react';
+import { motion, AnimatePresence } from 'framer-motion';
 
 const MainLayout = () => {
   const navigate = useNavigate();
   const location = useLocation();
   const { appointment, timeRemaining, isUrgent } = useNextAppointment();
+  const [showAppointmentFAB, setShowAppointmentFAB] = useState(false);
 
   // 중앙 버튼 클릭 핸들러 (Smart Navigation)
   const handleCenterButtonClick = () => {
-    // CRITICAL: localStorage에서 appointmentId 확인 (useNextAppointment보다 더 즉각적)
+    // CRITICAL: localStorage에서 appointmentId 확인 (엄격한 분기 처리)
     const savedAppointmentId = localStorage.getItem('appointmentId');
 
     // FIX: null 문자열 및 빈 값 명시적 체크
-    if (savedAppointmentId && savedAppointmentId !== 'null' && savedAppointmentId !== 'undefined') {
-      // Case A: 약속 ID 있음 -> 기존 약속 확인 페이지로
-      console.log('✅ 기존 약속 존재 -> 상세 페이지로 이동:', savedAppointmentId);
+    if (savedAppointmentId && savedAppointmentId !== 'null' && savedAppointmentId !== 'undefined' && savedAppointmentId.trim() !== '') {
+      // Case A: 약속 ID 있음 -> 무조건 내 약속 페이지로 (절대 피드로 가지 않음)
+      console.log('✅ 기존 약속 존재 -> 내 약속 상세 페이지로 이동:', savedAppointmentId);
       navigate(`/mission/${savedAppointmentId}`);
-    } else if (appointment) {
-      // Case A-2: hook에서 약속 발견 (fallback)
-      console.log('✅ 약속 발견 (hook) -> 상세 페이지로 이동:', appointment.id);
-      navigate(`/mission/${appointment.id}`);
     } else {
-      // Case B: 약속 없음 -> 위치 설정 후 새 약속 받기
-      console.log('📍 약속 없음 -> 위치 설정 페이지로 이동');
+      // Case B: 약속 없음 -> 위치 설정 후 새 약속 생성 (절대 피드로 가지 않음)
+      console.log('📍 약속 없음 -> 위치 설정 페이지로 이동 (새 약속 생성)');
       navigate('/location');
     }
   };
+
+  // 글로벌 약속 알림 FAB 로직
+  useEffect(() => {
+    const savedAppointmentId = localStorage.getItem('appointmentId');
+    const isOnMissionDetailPage = location.pathname.startsWith('/mission/');
+
+    // 조건: 약속이 있음 AND 현재 미션 상세 페이지가 아님
+    if (savedAppointmentId &&
+        savedAppointmentId !== 'null' &&
+        savedAppointmentId !== 'undefined' &&
+        savedAppointmentId.trim() !== '' &&
+        !isOnMissionDetailPage) {
+      setShowAppointmentFAB(true);
+    } else {
+      setShowAppointmentFAB(false);
+    }
+  }, [location.pathname]);
 
   const isActive = (path: string) => location.pathname === path;
 
@@ -33,6 +49,43 @@ const MainLayout = () => {
     <div className="min-h-screen bg-deep-charcoal pb-24">
       {/* 메인 콘텐츠 */}
       <Outlet />
+
+      {/* 진행 중인 약속 FAB (Floating Action Button) */}
+      <AnimatePresence>
+        {showAppointmentFAB && (
+          <motion.button
+            initial={{ opacity: 0, scale: 0.5, y: 20 }}
+            animate={{ opacity: 1, scale: 1, y: 0 }}
+            exit={{ opacity: 0, scale: 0.5, y: 20 }}
+            whileHover={{ scale: 1.1 }}
+            whileTap={{ scale: 0.95 }}
+            transition={{ type: 'spring', stiffness: 300, damping: 20 }}
+            onClick={() => {
+              const savedAppointmentId = localStorage.getItem('appointmentId');
+              if (savedAppointmentId) {
+                navigate(`/mission/${savedAppointmentId}`);
+              }
+            }}
+            className="fixed right-6 bottom-28 z-40 w-16 h-16 bg-gradient-to-br from-electric-lime to-neon-purple rounded-full shadow-lg shadow-electric-lime/50 flex items-center justify-center group"
+            style={{
+              boxShadow: '0 0 30px rgba(204, 255, 0, 0.6), 0 10px 20px rgba(0, 0, 0, 0.3)',
+            }}
+          >
+            {/* 티켓 아이콘 */}
+            <svg
+              className="w-8 h-8 text-deep-charcoal group-hover:rotate-12 transition-transform duration-300"
+              fill="currentColor"
+              viewBox="0 0 24 24"
+            >
+              <path d="M4 6h16v2H4zm0 5h16v2H4zm0 5h16v2H4z" opacity="0.3"/>
+              <path d="M21 3H3c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h18c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm0 16H3v-2h18v2zm0-4H3V9h18v6zm0-8H3V5h18v2z"/>
+            </svg>
+
+            {/* 펄스 애니메이션 링 */}
+            <span className="absolute inset-0 rounded-full border-2 border-electric-lime animate-ping opacity-75" />
+          </motion.button>
+        )}
+      </AnimatePresence>
 
       {/* 하단 네비게이션 (Glassmorphism) */}
       <nav className="fixed bottom-0 left-0 right-0 bg-charcoal-soft/95 backdrop-blur-lg border-t border-charcoal-lighter z-50">

--- a/frontend/src/pages/Appointments.tsx
+++ b/frontend/src/pages/Appointments.tsx
@@ -216,7 +216,7 @@ const Appointments = () => {
       case AppointmentStatus.COMPLETED:
         return <span className="px-2 py-1 bg-green-100 text-green-700 text-xs rounded-full">완료</span>;
       case AppointmentStatus.CANCELLED:
-        return <span className="px-2 py-1 bg-gray-100 text-gray-700 text-xs rounded-full">취소됨</span>;
+        return <span className="px-2 py-1 bg-charcoal-lighter text-text-gray text-xs rounded-full">취소됨</span>;
       default:
         return null;
     }
@@ -224,19 +224,19 @@ const Appointments = () => {
 
   if (isLoading) {
     return (
-      <div className="min-h-screen bg-[#FDFBF7] flex items-center justify-center">
-        <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-purple-600"></div>
+      <div className="min-h-screen bg-deep-charcoal flex items-center justify-center">
+        <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-electric-lime"></div>
       </div>
     );
   }
 
   return (
-    <div className="min-h-screen bg-[#FDFBF7]">
+    <div className="min-h-screen bg-deep-charcoal text-off-white">
       <div className="max-w-md mx-auto">
         {/* 헤더 */}
-        <div className="bg-[#FDFBF7] border-b border-gray-100 px-4 py-4">
+        <div className="bg-deep-charcoal border-b border-charcoal-lighter px-4 py-4">
           <div className="flex items-center justify-between mb-3">
-            <h1 className="text-xl font-bold text-gray-900">내 약속</h1>
+            <h1 className="text-xl font-bold text-off-white">내 약속</h1>
 
             <div className="flex items-center gap-2">
               {/* 즐겨찾기 필터 */}
@@ -244,8 +244,8 @@ const Appointments = () => {
                 onClick={() => setShowFavoritesOnly(!showFavoritesOnly)}
                 className={`px-3 py-1.5 rounded-full text-xs font-semibold transition ${
                   showFavoritesOnly
-                    ? 'bg-yellow-100 text-yellow-700'
-                    : 'bg-gray-100 text-gray-600 hover:bg-gray-200'
+                    ? 'bg-electric-lime/20 text-electric-lime'
+                    : 'bg-charcoal-lighter text-text-gray hover:bg-charcoal-soft'
                 }`}
               >
                 ⭐ {showFavoritesOnly ? '전체보기' : '즐겨찾기'}
@@ -258,7 +258,7 @@ const Appointments = () => {
                   setSelectedIds(new Set());
                 }}
                 className={`p-2 rounded-full transition ${
-                  isSelectionMode ? 'bg-red-100 text-red-600' : 'bg-gray-100 text-gray-600 hover:bg-gray-200'
+                  isSelectionMode ? 'bg-accent-pink/20 text-accent-pink' : 'bg-charcoal-lighter text-text-gray hover:bg-charcoal-soft'
                 }`}
               >
                 <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -274,8 +274,8 @@ const Appointments = () => {
               onClick={() => setFilter('all')}
               className={`px-4 py-2 rounded-full text-sm font-semibold whitespace-nowrap transition ${
                 filter === 'all'
-                  ? 'bg-purple-600 text-white'
-                  : 'bg-gray-100 text-gray-700 hover:bg-gray-200'
+                  ? 'bg-electric-lime text-deep-charcoal'
+                  : 'bg-charcoal-lighter text-text-gray hover:bg-charcoal-soft'
               }`}
             >
               전체 ({appointments.length})
@@ -284,8 +284,8 @@ const Appointments = () => {
               onClick={() => setFilter('active')}
               className={`px-4 py-2 rounded-full text-sm font-semibold whitespace-nowrap transition ${
                 filter === 'active'
-                  ? 'bg-purple-600 text-white'
-                  : 'bg-gray-100 text-gray-700 hover:bg-gray-200'
+                  ? 'bg-electric-lime text-deep-charcoal'
+                  : 'bg-charcoal-lighter text-text-gray hover:bg-charcoal-soft'
               }`}
             >
               진행 중
@@ -294,8 +294,8 @@ const Appointments = () => {
               onClick={() => setFilter('completed')}
               className={`px-4 py-2 rounded-full text-sm font-semibold whitespace-nowrap transition ${
                 filter === 'completed'
-                  ? 'bg-purple-600 text-white'
-                  : 'bg-gray-100 text-gray-700 hover:bg-gray-200'
+                  ? 'bg-electric-lime text-deep-charcoal'
+                  : 'bg-charcoal-lighter text-text-gray hover:bg-charcoal-soft'
               }`}
             >
               완료
@@ -304,8 +304,8 @@ const Appointments = () => {
               onClick={() => setFilter('cancelled')}
               className={`px-4 py-2 rounded-full text-sm font-semibold whitespace-nowrap transition ${
                 filter === 'cancelled'
-                  ? 'bg-purple-600 text-white'
-                  : 'bg-gray-100 text-gray-700 hover:bg-gray-200'
+                  ? 'bg-electric-lime text-deep-charcoal'
+                  : 'bg-charcoal-lighter text-text-gray hover:bg-charcoal-soft'
               }`}
             >
               취소
@@ -315,15 +315,15 @@ const Appointments = () => {
 
         {/* 다중 선택 모드 안내 */}
         {isSelectionMode && (
-          <div className="bg-purple-50 border-b border-purple-100 px-4 py-3">
+          <div className="bg-accent-pink/10 border-b border-accent-pink/20 px-4 py-3">
             <div className="flex items-center justify-between">
-              <span className="text-sm text-purple-700">
+              <span className="text-sm text-accent-pink">
                 {selectedIds.size > 0 ? `${selectedIds.size}개 선택됨` : '삭제할 약속을 선택하세요'}
               </span>
               {selectedIds.size > 0 && (
                 <button
                   onClick={handleBulkDelete}
-                  className="px-4 py-1.5 bg-red-600 text-white text-sm font-semibold rounded-lg hover:bg-red-700 transition"
+                  className="px-4 py-1.5 bg-accent-pink text-deep-charcoal text-sm font-semibold rounded-lg hover:bg-accent-pink/90 transition"
                 >
                   삭제하기
                 </button>
@@ -348,13 +348,13 @@ const Appointments = () => {
           {appointments.length === 0 ? (
             <div className="text-center py-20 px-4">
               <div className="text-6xl mb-4">📅</div>
-              <p className="text-gray-600">약속이 없어요</p>
-              <p className="text-sm text-gray-400 mt-2">새로운 약속을 잡아보세요!</p>
+              <p className="text-text-gray">약속이 없어요</p>
+              <p className="text-sm text-text-gray-dark mt-2">새로운 약속을 잡아보세요!</p>
             </div>
           ) : filteredAppointments.length === 0 && !upcomingAppointment ? (
             <div className="text-center py-20 px-4">
               <div className="text-6xl mb-4">🔍</div>
-              <p className="text-gray-600">
+              <p className="text-text-gray">
                 {showFavoritesOnly ? '즐겨찾기한 약속이 없어요' : '해당하는 약속이 없어요'}
               </p>
             </div>
@@ -362,7 +362,7 @@ const Appointments = () => {
             <>
               {filteredAppointments.length > 0 && (
                 <div className="px-4 pt-2 pb-1">
-                  <h2 className="text-sm font-semibold text-gray-500">지난 약속</h2>
+                  <h2 className="text-sm font-semibold text-text-gray">지난 약속</h2>
                 </div>
               )}
               {filteredAppointments.map((appointment) => (
@@ -375,7 +375,7 @@ const Appointments = () => {
                   onToggleFavorite={handleToggleFavorite}
                   onSwipeRight={() => handleSwipeRight(appointment.id)}
                 onSwipeLeft={() => handleSwipeLeft(appointment.id)}
-                onClick={() => !isSelectionMode && navigate(`/chat/${appointment.id}`)}
+                onClick={() => !isSelectionMode && navigate(`/mission/${appointment.id}`)}
                 getStatusBadge={getStatusBadge}
                 onDevUnlockTomorrow={handleDevUnlockTomorrow}
                 onDevUnlockNow={handleDevUnlockNow}
@@ -477,7 +477,7 @@ const SwipeableAppointmentItem = ({
         dragElastic={0.2}
         onDrag={(event, info) => setDragX(info.offset.x)}
         onDragEnd={handleDragEnd}
-        className="bg-[#FDFBF7] border-b border-gray-100 cursor-pointer"
+        className="bg-charcoal-soft border-b border-charcoal-lighter cursor-pointer"
       >
         <div
           onClick={isSelectionMode ? onToggleSelection : onClick}
@@ -504,7 +504,7 @@ const SwipeableAppointmentItem = ({
               {appointment.isFavorite ? (
                 <span className="text-yellow-500 text-xl">★</span>
               ) : (
-                <span className="text-gray-300 text-xl">☆</span>
+                <span className="text-charcoal-lighter text-xl">☆</span>
               )}
             </button>
           )}
@@ -512,24 +512,24 @@ const SwipeableAppointmentItem = ({
           {/* 내용 */}
           <div className="flex-1 min-w-0">
             <div className="flex items-start justify-between mb-1">
-              <h3 className="font-bold text-gray-900 truncate">
+              <h3 className="font-bold text-off-white truncate">
                 {appointment.missionTitle || '미션 미선택'}
               </h3>
               {getStatusBadge(appointment.status)}
             </div>
 
-            <p className="text-sm text-gray-600 mb-1">
+            <p className="text-sm text-text-gray mb-1">
               {formatDateTime(appointment.scheduledAt)}
             </p>
 
             {appointment.status === AppointmentStatus.ACCEPTED && (
-              <span className="text-xs font-semibold text-purple-600">
+              <span className="text-xs font-semibold text-electric-lime">
                 {calculateDday(appointment.scheduledAt)}
               </span>
             )}
 
             {appointment.placeName && (
-              <p className="text-xs text-gray-500 mt-1">
+              <p className="text-xs text-text-gray-dark mt-1">
                 📍 {appointment.placeName}
               </p>
             )}

--- a/frontend/src/pages/ChatAppointment.tsx
+++ b/frontend/src/pages/ChatAppointment.tsx
@@ -12,7 +12,7 @@ interface ChatMessage {
 }
 
 // 온보딩 단계
-type OnboardingStep = 'welcome' | 'nickname' | 'mbti' | 'solo-level' | 'complete';
+type OnboardingStep = 'welcome' | 'nickname' | 'mbti' | 'location' | 'preference' | 'complete';
 
 // 고유 ID 생성 함수
 const generateUniqueId = () => {
@@ -39,7 +39,8 @@ const ChatAppointment = () => {
   const [userData, setUserData] = useState({
     nickname: '',
     mbti: '',
-    soloLevel: 5,
+    defaultLocation: '',
+    preference: '', // 'OUTDOOR' or 'INDOOR'
   });
 
   // 자동 스크롤
@@ -123,39 +124,47 @@ const ChatAppointment = () => {
     addUserMessage(`${mbti}야.`);
     setShowChoices(false);
 
-    const response = mbti === 'I' 
-      ? '그렇겠지. 눈에 보이더라.' 
+    const response = mbti === 'I'
+      ? '그렇겠지. 눈에 보이더라.'
       : '오, 의외인데? 괜찮아.';
-    
+
     await addManagerMessage(response, 800);
-    setCurrentStep('solo-level');
-    await addManagerMessage('혼자 밥 먹는 거 레벨 몇? (1~10)', 500);
+    setCurrentStep('location');
+    await addManagerMessage('주로 어디서 출발해? (사는 곳이나 직장)', 500);
     setShowInput(true);
     setTimeout(() => inputRef.current?.focus(), 100);
   };
 
-  // 혼자 밥 먹기 레벨 처리
-  const handleSoloLevelSubmit = async () => {
-    const level = parseInt(inputValue.trim());
-    if (isNaN(level) || level < 1 || level > 10) {
-      await addManagerMessage('1부터 10 사이로 말해봐.', 500);
-      return;
-    }
+  // 위치 입력 처리
+  const handleLocationSubmit = async () => {
+    if (!inputValue.trim()) return;
 
-    const updatedUserData = { ...userData, soloLevel: level };
-    setUserData(updatedUserData);
-    addUserMessage(`레벨 ${level}`);
+    const location = inputValue.trim();
+    setUserData((prev) => ({ ...prev, defaultLocation: location }));
+    addUserMessage(location);
     setInputValue('');
     setShowInput(false);
 
-    let response = '';
-    if (level >= 8) {
-      response = '오... 프로네. 마음에 든다.';
-    } else if (level >= 5) {
-      response = '그 정도면 할 만하겠네.';
-    } else {
-      response = '괜찮아. 천천히 익숙해지면 돼.';
-    }
+    // localStorage에 default_location 저장
+    localStorage.setItem('default_location', location);
+    console.log('✅ 기본 위치 저장:', location);
+
+    await addManagerMessage(`${location}? 알았어.`, 800);
+    setCurrentStep('preference');
+    await addManagerMessage('야외가 좋아, 실내가 좋아?', 500);
+    setShowChoices(true);
+  };
+
+  // 선호 장소 선택 처리
+  const handlePreferenceSelect = async (preference: 'OUTDOOR' | 'INDOOR') => {
+    const updatedUserData = { ...userData, preference };
+    setUserData(updatedUserData);
+    addUserMessage(preference === 'OUTDOOR' ? '야외가 좋아.' : '실내가 좋아.');
+    setShowChoices(false);
+
+    const response = preference === 'OUTDOOR'
+      ? '오, 활동적이네. 좋아.'
+      : '실내파구나. 알겠어.';
 
     await addManagerMessage(response, 800);
     setCurrentStep('complete');
@@ -216,8 +225,8 @@ const ChatAppointment = () => {
     if (e.key === 'Enter') {
       if (currentStep === 'nickname') {
         handleNicknameSubmit();
-      } else if (currentStep === 'solo-level') {
-        handleSoloLevelSubmit();
+      } else if (currentStep === 'location') {
+        handleLocationSubmit();
       }
     }
   };
@@ -325,6 +334,28 @@ const ChatAppointment = () => {
           </motion.div>
         )}
 
+        {/* Preference 선택 버튼 */}
+        {showChoices && currentStep === 'preference' && (
+          <motion.div
+            initial={{ opacity: 0, y: 10 }}
+            animate={{ opacity: 1, y: 0 }}
+            className="flex justify-end gap-3"
+          >
+            <button
+              onClick={() => handlePreferenceSelect('OUTDOOR')}
+              className="px-6 py-3 bg-charcoal-soft text-off-white rounded-2xl hover:bg-charcoal-lighter transition-all border border-electric-lime/30 hover:border-electric-lime"
+            >
+              야외
+            </button>
+            <button
+              onClick={() => handlePreferenceSelect('INDOOR')}
+              className="px-6 py-3 bg-charcoal-soft text-off-white rounded-2xl hover:bg-charcoal-lighter transition-all border border-electric-lime/30 hover:border-electric-lime"
+            >
+              실내
+            </button>
+          </motion.div>
+        )}
+
         <div ref={messagesEndRef} />
       </main>
 
@@ -382,14 +413,14 @@ const ChatAppointment = () => {
         )}
       </AnimatePresence>
 
-      {/* 입력창 */}
+      {/* 입력창 - 모바일 CSS 최적화 */}
       {showInput && (
         <motion.div
           initial={{ y: 100, opacity: 0 }}
           animate={{ y: 0, opacity: 1 }}
-          className="fixed bottom-0 left-0 right-0 bg-charcoal-soft border-t border-charcoal-lighter p-4"
+          className="fixed bottom-0 left-0 right-0 bg-charcoal-soft border-t border-charcoal-lighter p-4 safe-area-inset-bottom"
         >
-          <div className="container-solotion flex gap-3 items-center">
+          <div className="container-solotion flex gap-2 sm:gap-3 items-center">
             <input
               ref={inputRef}
               type="text"
@@ -399,22 +430,22 @@ const ChatAppointment = () => {
               placeholder={
                 currentStep === 'nickname'
                   ? '닉네임 입력...'
-                  : currentStep === 'solo-level'
-                  ? '1~10 숫자 입력...'
+                  : currentStep === 'location'
+                  ? '지역 입력 (예: 강남, 홍대)...'
                   : '입력...'
               }
-              className="flex-1 bg-charcoal-lighter text-off-white px-4 py-3 rounded-full border border-charcoal-lighter focus:border-electric-lime focus:outline-none transition-colors placeholder-text-gray-dark"
+              className="flex-1 min-w-0 bg-charcoal-lighter text-off-white px-4 py-3 rounded-full border border-charcoal-lighter focus:border-electric-lime focus:outline-none transition-colors placeholder-text-gray-dark"
             />
             <button
               onClick={() => {
                 if (currentStep === 'nickname') {
                   handleNicknameSubmit();
-                } else if (currentStep === 'solo-level') {
-                  handleSoloLevelSubmit();
+                } else if (currentStep === 'location') {
+                  handleLocationSubmit();
                 }
               }}
               disabled={!inputValue.trim()}
-              className="bg-electric-lime text-deep-charcoal px-6 py-3 rounded-full font-bold hover:bg-electric-lime/90 transition-all disabled:opacity-50 disabled:cursor-not-allowed"
+              className="flex-shrink-0 bg-electric-lime text-deep-charcoal px-4 sm:px-6 py-3 rounded-full font-bold hover:bg-electric-lime/90 transition-all disabled:opacity-50 disabled:cursor-not-allowed min-w-[60px] text-sm sm:text-base"
             >
               전송
             </button>

--- a/frontend/src/pages/FeedPage.tsx
+++ b/frontend/src/pages/FeedPage.tsx
@@ -1,11 +1,17 @@
 import { useState, useEffect } from 'react';
 import { motion } from 'framer-motion';
-import { MessageCircle, Bookmark, Clock } from 'lucide-react';
-import { getPublicFeed, FeedItem } from '../api/appointmentApi';
+import { MessageCircle, Bookmark, Clock, Calendar } from 'lucide-react';
+import { getPublicFeed, FeedItem, toggleSaveAppointment, toggleLikeAppointment } from '../api/appointmentApi';
 import { formatDistanceToNow } from 'date-fns';
 import { ko } from 'date-fns/locale';
+import { useNavigate } from 'react-router-dom';
+import EscLikeButton from '../components/EscLikeButton';
+import ScrollToTopButton from '../components/ScrollToTopButton';
+import { useInfiniteScroll } from '../hooks/useInfiniteScroll';
+import { showToast } from '../utils/toast';
 
 const FeedPage = () => {
+  const navigate = useNavigate();
   const [feeds, setFeeds] = useState<FeedItem[]>([]);
   const [loading, setLoading] = useState(true);
   const [page, setPage] = useState(0);
@@ -15,16 +21,16 @@ const FeedPage = () => {
     loadFeeds();
   }, []);
 
-  const loadFeeds = async () => {
+  const loadFeeds = async (pageNum: number = page) => {
     try {
       setLoading(true);
-      const data = await getPublicFeed(page, 20);
+      const data = await getPublicFeed(pageNum, 20);
 
       if (data.length < 20) {
         setHasMore(false);
       }
 
-      setFeeds(prev => page === 0 ? data : [...prev, ...data]);
+      setFeeds(prev => pageNum === 0 ? data : [...prev, ...data]);
     } catch (error) {
       console.error('피드 로딩 실패:', error);
     } finally {
@@ -34,8 +40,99 @@ const FeedPage = () => {
 
   const loadMore = () => {
     if (!loading && hasMore) {
-      setPage(prev => prev + 1);
-      loadFeeds();
+      const nextPage = page + 1;
+      setPage(nextPage);
+      loadFeeds(nextPage);
+    }
+  };
+
+  // Infinite Scroll 훅 사용
+  const observerTarget = useInfiniteScroll({
+    onLoadMore: loadMore,
+    hasMore,
+    loading,
+    threshold: 0.5,
+  });
+
+  // 좋아요 토글 핸들러
+  const handleToggleLike = async (appointmentId: number) => {
+    try {
+      // 낙관적 업데이트 (Optimistic Update)
+      setFeeds(prev =>
+        prev.map(feed =>
+          feed.appointmentId === appointmentId
+            ? { ...feed, isLikedByMe: !feed.isLikedByMe }
+            : feed
+        )
+      );
+
+      const isLiked = await toggleLikeAppointment(appointmentId);
+
+      // API 응답과 동기화
+      setFeeds(prev =>
+        prev.map(feed =>
+          feed.appointmentId === appointmentId
+            ? { ...feed, isLikedByMe: isLiked }
+            : feed
+        )
+      );
+
+      if (isLiked) {
+        showToast('좋아요! 💚');
+      }
+    } catch (error) {
+      console.error('좋아요 토글 실패:', error);
+      // 실패 시 원래 상태로 롤백
+      setFeeds(prev =>
+        prev.map(feed =>
+          feed.appointmentId === appointmentId
+            ? { ...feed, isLikedByMe: !feed.isLikedByMe }
+            : feed
+        )
+      );
+      showToast('좋아요 중 오류가 발생했어요');
+    }
+  };
+
+  // 북마크 토글 핸들러
+  const handleToggleSave = async (appointmentId: number) => {
+    try {
+      // 낙관적 업데이트
+      setFeeds(prev =>
+        prev.map(feed =>
+          feed.appointmentId === appointmentId
+            ? { ...feed, isSavedByMe: !feed.isSavedByMe }
+            : feed
+        )
+      );
+
+      const isSaved = await toggleSaveAppointment(appointmentId);
+
+      // API 응답과 동기화
+      setFeeds(prev =>
+        prev.map(feed =>
+          feed.appointmentId === appointmentId
+            ? { ...feed, isSavedByMe: isSaved }
+            : feed
+        )
+      );
+
+      if (isSaved) {
+        showToast('저장한 일탈 목록에 추가했어요 📂');
+      } else {
+        showToast('저장 목록에서 제거했어요');
+      }
+    } catch (error) {
+      console.error('북마크 토글 실패:', error);
+      // 실패 시 원래 상태로 롤백
+      setFeeds(prev =>
+        prev.map(feed =>
+          feed.appointmentId === appointmentId
+            ? { ...feed, isSavedByMe: !feed.isSavedByMe }
+            : feed
+        )
+      );
+      showToast('저장하는 중 오류가 발생했어요');
     }
   };
 
@@ -63,8 +160,16 @@ const FeedPage = () => {
       {/* Header */}
       <header className="bg-charcoal-soft/95 backdrop-blur-lg border-b border-charcoal-lighter sticky top-0 z-10">
         <div className="container-solotion py-4">
-          <h1 className="text-off-white text-2xl font-extra-bold">피드</h1>
-          <p className="text-text-gray text-sm mt-1">다른 사람들의 작은 일탈</p>
+          <div className="flex items-center justify-between">
+            <h1 className="text-off-white text-2xl font-extra-bold">잘 쉰 사람들 목록</h1>
+            <button
+              onClick={() => navigate('/appointments')}
+              className="flex items-center gap-2 px-4 py-2 bg-charcoal-lighter hover:bg-charcoal-lighter/80 text-off-white rounded-lg transition"
+            >
+              <Calendar size={18} />
+              <span className="text-sm font-bold">나의 쉼</span>
+            </button>
+          </div>
         </div>
       </header>
 
@@ -77,9 +182,9 @@ const FeedPage = () => {
             className="text-center py-20"
           >
             <div className="text-6xl mb-4">🌍</div>
-            <p className="text-text-gray mb-2">아직 공개된 인증샷이 없어요</p>
+            <p className="text-text-gray mb-2">아직 제대로 쉰 사람이 없어요</p>
             <p className="text-text-gray-dark text-sm">
-              먼저 미션을 완료하고 인증해보세요!
+              쉬었음과 함께 제대로 쉬어요
             </p>
           </motion.div>
         ) : (
@@ -220,16 +325,36 @@ const FeedPage = () => {
                 )}
 
                 {/* Action Buttons */}
-                <div className="flex items-center gap-4 pt-3 border-t border-charcoal-lighter">
-                  <button className="flex items-center gap-1 text-text-gray hover:text-electric-lime transition">
-                    <MessageCircle size={18} />
-                    <span className="text-sm">댓글</span>
-                  </button>
+                <div className="flex items-center justify-between pt-3 border-t border-charcoal-lighter">
+                  <div className="flex items-center gap-4">
+                    <button className="flex items-center gap-1 text-text-gray hover:text-electric-lime transition">
+                      <MessageCircle size={18} />
+                      <span className="text-sm">댓글</span>
+                    </button>
 
-                  <button className="flex items-center gap-1 text-text-gray hover:text-electric-lime transition">
-                    <Bookmark size={18} />
-                    <span className="text-sm">저장</span>
-                  </button>
+                    <button
+                      onClick={() => handleToggleSave(feed.appointmentId)}
+                      className={`flex items-center gap-1 transition ${
+                        feed.isSavedByMe
+                          ? 'text-electric-lime'
+                          : 'text-text-gray hover:text-electric-lime'
+                      }`}
+                    >
+                      <Bookmark
+                        size={18}
+                        fill={feed.isSavedByMe ? 'currentColor' : 'none'}
+                      />
+                      <span className="text-sm">
+                        {feed.isSavedByMe ? '저장됨' : '저장'}
+                      </span>
+                    </button>
+                  </div>
+
+                  {/* ESC 좋아요 버튼 */}
+                  <EscLikeButton
+                    isLiked={feed.isLikedByMe}
+                    onLike={() => handleToggleLike(feed.appointmentId)}
+                  />
                 </div>
               </div>
             </motion.div>
@@ -237,17 +362,36 @@ const FeedPage = () => {
           })
         )}
 
-        {/* Load More Button */}
+        {/* Infinite Scroll Observer Target */}
         {hasMore && feeds.length > 0 && (
-          <button
-            onClick={loadMore}
-            disabled={loading}
-            className="btn-secondary w-full disabled:opacity-50"
-          >
-            {loading ? '로딩 중...' : '더보기'}
-          </button>
+          <div ref={observerTarget} className="py-8 flex justify-center">
+            {loading && (
+              <motion.div
+                initial={{ opacity: 0 }}
+                animate={{ opacity: 1 }}
+                className="flex items-center gap-3 text-text-gray"
+              >
+                <motion.div
+                  animate={{ rotate: 360 }}
+                  transition={{ repeat: Infinity, duration: 1, ease: 'linear' }}
+                  className="w-6 h-6 border-2 border-electric-lime/30 border-t-electric-lime rounded-full"
+                />
+                <span className="text-sm">더 많은 피드를 불러오는 중...</span>
+              </motion.div>
+            )}
+          </div>
+        )}
+
+        {/* 더 이상 피드가 없을 때 */}
+        {!hasMore && feeds.length > 0 && (
+          <div className="py-8 text-center text-text-gray-dark text-sm">
+            모든 피드를 확인했어요 ✨
+          </div>
         )}
       </div>
+
+      {/* Scroll to Top FAB */}
+      <ScrollToTopButton threshold={300} />
     </div>
   );
 };

--- a/frontend/src/pages/LocationSetting.tsx
+++ b/frontend/src/pages/LocationSetting.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { motion } from 'framer-motion';
+import { showToast } from '../utils/toast';
 
 interface Location {
   lat: number;
@@ -37,18 +38,22 @@ const LocationSetting = () => {
         },
         (error) => {
           console.warn('위치 확인 실패:', error);
-          setGeoError('위치 확인 실패. 아래에서 핫플을 선택해주세요.');
-          // 기본값: 성수
+
+          // 기본값: 성수동으로 자동 설정
           setSelectedLocation({
             lat: 37.5445,
             lng: 127.0557,
             name: '성수',
           });
           setIsLoadingGeo(false);
+
+          // 사용자 친화적 토스트 메시지 표시
+          showToast('위치를 찾을 수 없어 성수동으로 설정했어요.');
+          setGeoError('위치를 찾을 수 없어 성수동으로 설정했어요. 아래에서 다른 핫플을 선택할 수 있어요.');
         },
         {
           enableHighAccuracy: true,
-          timeout: 5000,
+          timeout: 10000,
           maximumAge: 0,
         }
       );
@@ -60,6 +65,7 @@ const LocationSetting = () => {
         name: '성수',
       });
       setIsLoadingGeo(false);
+      showToast('위치를 찾을 수 없어 성수동으로 설정했어요.');
     }
   }, []);
 

--- a/frontend/src/pages/MissionDetail.tsx
+++ b/frontend/src/pages/MissionDetail.tsx
@@ -75,6 +75,10 @@ function MissionDetail() {
   // 긍정 강화 토스트 상태
   const [showPositiveToast, setShowPositiveToast] = useState<boolean>(false);
 
+  // 스크롤 감지 상태
+  const [isScrollingDown, setIsScrollingDown] = useState<boolean>(false);
+  const [lastScrollY, setLastScrollY] = useState<number>(0);
+
   // 가이드 파싱
   const parseGuide = (guideJson?: string): GuideStep[] => {
     if (!guideJson) return [];
@@ -90,7 +94,7 @@ function MissionDetail() {
     const loadAppointment = async () => {
       if (!appointmentId) {
         alert('약속 ID가 없어.');
-        navigate('/mypage');
+        navigate('/appointments');
         return;
       }
 
@@ -100,7 +104,7 @@ function MissionDetail() {
       } catch (err) {
         console.error('약속 로딩 실패:', err);
         alert('약속 정보를 불러오는데 실패했어.');
-        navigate('/mypage');
+        navigate('/appointments');
       } finally {
         setLoading(false);
       }
@@ -108,6 +112,28 @@ function MissionDetail() {
 
     loadAppointment();
   }, [appointmentId, navigate]);
+
+  // 스크롤 감지 (Smart Scroll Buttons)
+  useEffect(() => {
+    const handleScroll = () => {
+      const currentScrollY = window.scrollY;
+
+      // 스크롤 방향 감지 (50px 이상 이동 시에만 반응)
+      if (Math.abs(currentScrollY - lastScrollY) > 50) {
+        if (currentScrollY > lastScrollY && currentScrollY > 100) {
+          // 아래로 스크롤 중
+          setIsScrollingDown(true);
+        } else {
+          // 위로 스크롤 중
+          setIsScrollingDown(false);
+        }
+        setLastScrollY(currentScrollY);
+      }
+    };
+
+    window.addEventListener('scroll', handleScroll, { passive: true });
+    return () => window.removeEventListener('scroll', handleScroll);
+  }, [lastScrollY]);
 
   // D-Day 계산
   const getDdayText = (scheduledAt: string): string => {
@@ -377,7 +403,7 @@ function MissionDetail() {
       );
 
       alert('수고했어!');
-      navigate('/mypage');
+      navigate('/appointments');
     } catch (err) {
       alert('완료 처리에 실패했어. 다시 시도해봐.');
     } finally {
@@ -413,11 +439,18 @@ function MissionDetail() {
   const isStep3Unlocked = isArrived;
 
   return (
-    <div className="min-h-screen bg-deep-charcoal flex flex-col">
+    <div className="min-h-screen bg-deep-charcoal flex flex-col pb-24">
       {/* ===== Header ===== */}
       <header className="px-4 sm:px-6 py-6 flex items-center justify-between border-b border-charcoal-lighter sticky top-0 z-20 bg-deep-charcoal/95 backdrop-blur-sm">
         <button
-          onClick={() => navigate('/mypage')}
+          onClick={() => {
+            // Smart Navigation: 이전 페이지로 이동 (location.state?.from 또는 브라우저 히스토리)
+            if (location.state?.from) {
+              navigate(location.state.from);
+            } else {
+              navigate(-1);
+            }
+          }}
           className="flex items-center gap-2 text-text-gray hover:text-off-white transition-colors"
         >
           <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -426,8 +459,8 @@ function MissionDetail() {
           <span className="font-semibold">뒤로</span>
         </button>
 
-        {/* D-Day 카운터 */}
-        <div className="bg-electric-lime text-deep-charcoal px-4 py-2 rounded-solotion font-extra-bold text-lg">
+        {/* D-Day 라벨 (버튼처럼 보이지 않게) */}
+        <div className="bg-electric-lime/20 text-electric-lime px-4 py-2 rounded-solotion font-extra-bold text-lg cursor-default select-none">
           {getDdayText(appointment.scheduledAt)}
         </div>
 
@@ -901,65 +934,74 @@ function MissionDetail() {
       </main>
 
       {/* ===== Feed Button (약속 구경) ===== */}
-      <motion.button
-        onClick={() => navigate('/feed')}
-        initial={{ scale: 0, opacity: 0 }}
-        animate={{ scale: 1, opacity: 1 }}
-        transition={{ delay: 0.2, type: 'spring', stiffness: 200 }}
-        whileHover={{ scale: 1.05 }}
-        whileTap={{ scale: 0.95 }}
-        className="fixed bottom-24 right-4 sm:right-6 z-40"
+      {/* ===== 하단 액션 버튼 그룹 (Smart Scroll) ===== */}
+      <motion.div
+        initial={{ x: 0 }}
+        animate={{ x: isScrollingDown ? '120%' : 0 }}
+        transition={{ type: 'spring', stiffness: 300, damping: 30 }}
+        className="fixed bottom-6 right-4 sm:right-6 z-40 flex flex-col gap-3"
       >
-        <div className="bg-electric-lime text-deep-charcoal px-5 sm:px-6 py-3 sm:py-4 rounded-full shadow-2xl font-bold text-sm sm:text-base whitespace-nowrap flex items-center gap-2">
-          <span>📸</span>
-          <span>약속 구경</span>
-        </div>
-      </motion.button>
-
-      {/* ===== Escape FAB (Floating Action Button) ===== */}
-      {appointment.status !== 'COMPLETED' && appointment.status !== 'CANCELLED' && (
+        {/* 피드 구경 버튼 */}
         <motion.button
-          onClick={() => setShowPlanBModal(true)}
+          onClick={() => navigate('/feed')}
           initial={{ scale: 0, opacity: 0 }}
           animate={{ scale: 1, opacity: 1 }}
-          transition={{ delay: 0.3, type: 'spring', stiffness: 200 }}
+          transition={{ delay: 0.2, type: 'spring', stiffness: 200 }}
           whileHover={{ scale: 1.05 }}
           whileTap={{ scale: 0.95 }}
-          className="fixed bottom-6 right-4 sm:right-6 z-40 group"
+          className="flex-1"
         >
-          {/* Glassmorphism 버튼 */}
-          <div className="relative">
-            {/* 네온 글로우 효과 */}
-            <div className="absolute inset-0 bg-electric-lime/30 blur-xl rounded-full animate-pulse"></div>
-
-            {/* 메인 버튼 */}
-            <div className="relative backdrop-blur-xl bg-charcoal-soft/80 border-2 border-electric-lime/50 rounded-full shadow-2xl overflow-hidden">
-              {/* 호버 시 배경 효과 */}
-              <div className="absolute inset-0 bg-gradient-to-br from-electric-lime/20 to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-300"></div>
-
-              {/* 버튼 콘텐츠 */}
-              <div className="relative px-4 sm:px-6 py-3 sm:py-4 flex items-center gap-2 sm:gap-3">
-                {/* 비상구 아이콘 */}
-                <div className="text-2xl animate-bounce">
-                  <svg
-                    className="w-6 h-6 sm:w-7 sm:h-7 text-electric-lime"
-                    fill="none"
-                    stroke="currentColor"
-                    viewBox="0 0 24 24"
-                  >
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2.5} d="M17 8l4 4m0 0l-4 4m4-4H3" />
-                  </svg>
-                </div>
-
-                {/* 텍스트 라벨 */}
-                <span className="text-off-white font-bold text-sm sm:text-base whitespace-nowrap">
-                  다른 거 할래
-                </span>
-              </div>
-            </div>
+          <div className="bg-electric-lime text-deep-charcoal px-5 sm:px-6 py-3 sm:py-4 rounded-full shadow-2xl font-bold text-sm sm:text-base whitespace-nowrap flex items-center justify-center gap-2">
+            <span>📸</span>
+            <span>피드 구경</span>
           </div>
         </motion.button>
-      )}
+
+        {/* 다른 거 할래 버튼 */}
+        {appointment.status !== 'COMPLETED' && appointment.status !== 'CANCELLED' && (
+          <motion.button
+            onClick={() => setShowPlanBModal(true)}
+            initial={{ scale: 0, opacity: 0 }}
+            animate={{ scale: 1, opacity: 1 }}
+            transition={{ delay: 0.3, type: 'spring', stiffness: 200 }}
+            whileHover={{ scale: 1.05 }}
+            whileTap={{ scale: 0.95 }}
+            className="flex-1 group"
+          >
+            {/* Glassmorphism 버튼 */}
+            <div className="relative">
+              {/* 네온 글로우 효과 */}
+              <div className="absolute inset-0 bg-electric-lime/30 blur-xl rounded-full animate-pulse"></div>
+
+              {/* 메인 버튼 */}
+              <div className="relative backdrop-blur-xl bg-charcoal-soft/80 border-2 border-electric-lime/50 rounded-full shadow-2xl overflow-hidden">
+                {/* 호버 시 배경 효과 */}
+                <div className="absolute inset-0 bg-gradient-to-br from-electric-lime/20 to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-300"></div>
+
+                {/* 버튼 콘텐츠 */}
+                <div className="relative px-4 sm:px-6 py-3 sm:py-4 flex items-center justify-center gap-2 sm:gap-3">
+                  {/* 비상구 아이콘 */}
+                  <div className="text-2xl animate-bounce">
+                    <svg
+                      className="w-6 h-6 sm:w-7 sm:h-7 text-electric-lime"
+                      fill="none"
+                      stroke="currentColor"
+                      viewBox="0 0 24 24"
+                    >
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2.5} d="M17 8l4 4m0 0l-4 4m4-4H3" />
+                    </svg>
+                  </div>
+
+                  {/* 텍스트 라벨 */}
+                  <span className="text-off-white font-bold text-sm sm:text-base whitespace-nowrap">
+                    이거 말고
+                  </span>
+                </div>
+              </div>
+            </div>
+          </motion.button>
+        )}
+      </motion.div>
 
       {/* ===== Arrival Success Modal ===== */}
       <AnimatePresence>

--- a/frontend/src/pages/MyPage.tsx
+++ b/frontend/src/pages/MyPage.tsx
@@ -70,6 +70,13 @@ const MyPage = () => {
 
   const menuItems = [
     {
+      icon: '📂',
+      title: '저장한 일탈',
+      description: '마음에 든 약속 모아보기',
+      onClick: () => navigate('/mypage/saved'),
+      highlight: true, // 새 기능 강조
+    },
+    {
       icon: '✏️',
       title: '프로필 수정',
       description: '닉네임, 프로필 사진 변경하기',

--- a/frontend/src/pages/SavedAppointments.tsx
+++ b/frontend/src/pages/SavedAppointments.tsx
@@ -1,0 +1,168 @@
+import { useState, useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { motion } from 'framer-motion';
+import { ArrowLeft, MapPin } from 'lucide-react';
+import { getSavedAppointments, FeedItem, toggleSaveAppointment } from '../api/appointmentApi';
+import { showToast } from '../utils/toast';
+
+const SavedAppointments = () => {
+  const navigate = useNavigate();
+  const [savedAppointments, setSavedAppointments] = useState<FeedItem[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    loadSavedAppointments();
+  }, []);
+
+  const loadSavedAppointments = async () => {
+    try {
+      setLoading(true);
+      const data = await getSavedAppointments();
+      setSavedAppointments(data);
+    } catch (error) {
+      console.error('저장 목록 로딩 실패:', error);
+      showToast('저장 목록을 불러오는 중 오류가 발생했어요');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleUnsave = async (appointmentId: number) => {
+    try {
+      await toggleSaveAppointment(appointmentId);
+      // 로컬 상태에서 제거
+      setSavedAppointments(prev => prev.filter(item => item.appointmentId !== appointmentId));
+      showToast('저장 목록에서 제거했어요');
+    } catch (error) {
+      console.error('저장 취소 실패:', error);
+      showToast('저장 취소 중 오류가 발생했어요');
+    }
+  };
+
+  if (loading) {
+    return (
+      <div className="min-h-screen bg-deep-charcoal flex items-center justify-center">
+        <motion.div
+          initial={{ opacity: 0, scale: 0.8 }}
+          animate={{ opacity: 1, scale: 1 }}
+          transition={{
+            duration: 0.6,
+            repeat: Infinity,
+            repeatType: 'reverse',
+          }}
+          className="text-2xl text-off-white font-bold"
+        >
+          📂
+        </motion.div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-deep-charcoal pb-24">
+      {/* Header */}
+      <header className="bg-charcoal-soft/95 backdrop-blur-lg border-b border-charcoal-lighter sticky top-0 z-10">
+        <div className="container-solotion py-4 flex items-center gap-3">
+          <button
+            onClick={() => navigate(-1)}
+            className="text-off-white hover:text-electric-lime transition"
+          >
+            <ArrowLeft size={24} />
+          </button>
+          <div>
+            <h1 className="text-off-white text-2xl font-extra-bold">저장한 일탈</h1>
+            <p className="text-text-gray text-sm mt-1">
+              {savedAppointments.length}개의 약속을 저장했어요
+            </p>
+          </div>
+        </div>
+      </header>
+
+      {/* Saved List */}
+      <div className="container-solotion py-6">
+        {savedAppointments.length === 0 ? (
+          <motion.div
+            initial={{ opacity: 0, y: 20 }}
+            animate={{ opacity: 1, y: 0 }}
+            className="text-center py-20"
+          >
+            <div className="text-6xl mb-4">📂</div>
+            <p className="text-text-gray mb-2">아직 저장한 일탈이 없어요</p>
+            <p className="text-text-gray-dark text-sm mb-6">
+              피드에서 마음에 드는 약속을 저장해보세요!
+            </p>
+            <button
+              onClick={() => navigate('/feed')}
+              className="btn-primary"
+            >
+              피드 둘러보기
+            </button>
+          </motion.div>
+        ) : (
+          <div className="grid grid-cols-2 gap-4">
+            {savedAppointments.map((item, index) => (
+              <motion.div
+                key={item.appointmentId}
+                initial={{ opacity: 0, y: 20 }}
+                animate={{ opacity: 1, y: 0 }}
+                transition={{ delay: index * 0.05 }}
+                className="card p-0 overflow-hidden relative group cursor-pointer"
+                onClick={() => {
+                  // 저장한 일탈 상세 보기 (MissionDetail 재활용)
+                  navigate(`/mission/${item.appointmentId}`);
+                }}
+              >
+                {/* 썸네일 */}
+                <div className="relative h-40 bg-charcoal-lighter">
+                  {item.proofImageUrls && item.proofImageUrls.length > 0 ? (
+                    <img
+                      src={`${import.meta.env.VITE_API_BASE_URL}${item.proofImageUrls[0]}`}
+                      alt={item.missionTitle}
+                      className="w-full h-full object-cover"
+                      onError={(e) => {
+                        e.currentTarget.src = 'https://images.unsplash.com/photo-1502134249126-9f3755a50d78?w=400&q=80';
+                      }}
+                    />
+                  ) : (
+                    <div className="w-full h-full flex items-center justify-center text-4xl">
+                      ✨
+                    </div>
+                  )}
+
+                  {/* 삭제 버튼 (호버 시 표시) */}
+                  <button
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      handleUnsave(item.appointmentId);
+                    }}
+                    className="absolute top-2 right-2 bg-deep-charcoal/80 text-off-white p-2 rounded-full opacity-0 group-hover:opacity-100 transition-opacity hover:bg-accent-pink"
+                  >
+                    <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+                    </svg>
+                  </button>
+                </div>
+
+                {/* 정보 */}
+                <div className="p-3">
+                  <h3 className="text-off-white font-bold text-sm mb-1 line-clamp-1">
+                    {item.missionTitle}
+                  </h3>
+                  <div className="flex items-center gap-1 text-text-gray text-xs">
+                    <MapPin size={12} />
+                    <span className="line-clamp-1">{item.placeName}</span>
+                  </div>
+                  <p className="text-text-gray-dark text-xs mt-1">
+                    {item.userNickname}
+                  </p>
+                </div>
+              </motion.div>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default SavedAppointments;

--- a/frontend/src/pages/TimePicker.tsx
+++ b/frontend/src/pages/TimePicker.tsx
@@ -3,6 +3,7 @@ import { useNavigate } from 'react-router-dom';
 import { motion } from 'framer-motion';
 import { createAppointment } from '../api/appointmentApi';
 import { ChevronLeft } from 'lucide-react';
+import { showToast } from '../utils/toast';
 
 const TimePicker = () => {
   const navigate = useNavigate();
@@ -43,9 +44,31 @@ const TimePicker = () => {
     };
   };
 
+  // 약속 상태 초기화 함수
+  const resetAppointmentState = () => {
+    console.log('🔄 약속 상태 초기화');
+    setSelectedDate(null);
+    setSelectedTime(null);
+    localStorage.removeItem('appointmentId');
+    localStorage.removeItem('selected_mission');
+    console.log('✅ 약속 관련 데이터 싹 제거 완료');
+  };
+
+  // 뒤로 가기 핸들러
+  const handleGoBack = () => {
+    if (selectedDate || selectedTime) {
+      if (confirm('선택한 시간 정보가 초기화됩니다. 뒤로 가시겠어요?')) {
+        resetAppointmentState();
+        navigate('/location');
+      }
+    } else {
+      navigate('/location');
+    }
+  };
+
   const handleConfirm = async () => {
     if (!selectedDate || !selectedTime) {
-      alert('날짜와 시간을 모두 선택해주세요.');
+      showToast('약속 시간을 정해야 추천해줄 수 있어!');
       return;
     }
 
@@ -101,7 +124,7 @@ const TimePicker = () => {
       {/* Header */}
       <header className="container-solotion py-6">
         <button
-          onClick={() => navigate('/location')}
+          onClick={handleGoBack}
           className="mb-4 text-text-gray hover:text-off-white transition flex items-center gap-2"
         >
           <ChevronLeft size={20} />
@@ -229,12 +252,16 @@ const TimePicker = () => {
           transition={{ delay: 0.3, duration: 0.5 }}
           onClick={handleConfirm}
           disabled={!selectedDate || !selectedTime || isLoading}
-          className="btn-primary w-full text-xl py-4 disabled:opacity-50 disabled:cursor-not-allowed"
+          className={`w-full text-xl py-4 font-bold rounded-solotion transition-all ${
+            !selectedDate || !selectedTime || isLoading
+              ? 'bg-charcoal-lighter text-text-gray cursor-not-allowed'
+              : 'btn-primary hover:scale-105 active:scale-95'
+          }`}
         >
           {isLoading
             ? '약속 생성 중...'
             : selectedDate && selectedTime
-            ? `${formatDate(selectedDate).short} ${selectedTime}에 출발하기 🚀`
+            ? `좋아, 나갈게 🚀`
             : '날짜와 시간을 선택해주세요'}
         </motion.button>
       </footer>

--- a/frontend/src/routes/RouteGuards.tsx
+++ b/frontend/src/routes/RouteGuards.tsx
@@ -1,0 +1,114 @@
+import { ReactNode } from 'react';
+import { Navigate, useLocation } from 'react-router-dom';
+
+/**
+ * 뉴비 전용 라우트 가드
+ * 이미 온보딩을 완료했거나 약속이 있는 사용자는 접근 불가
+ * 용도: /chat (온보딩) 보호
+ */
+export const RequireNewUser = ({ children }: { children: ReactNode }) => {
+  const location = useLocation();
+  const onboardingComplete = localStorage.getItem('onboarding_complete');
+  const appointmentId = localStorage.getItem('appointmentId');
+
+  // 약속이 있는 경우 -> 미션 상세 페이지로 강제 이동
+  if (appointmentId && appointmentId !== 'null' && appointmentId !== 'undefined') {
+    console.warn('⚠️ [RequireNewUser] 약속이 있는 유저 -> /mission으로 리다이렉트');
+    return <Navigate to={`/mission/${appointmentId}`} replace />;
+  }
+
+  // 온보딩 완료한 경우 -> 피드로 이동
+  if (onboardingComplete === 'true') {
+    console.warn('⚠️ [RequireNewUser] 온보딩 완료 유저 -> /feed로 리다이렉트');
+    return <Navigate to="/feed" replace />;
+  }
+
+  return <>{children}</>;
+};
+
+/**
+ * 약속 필수 라우트 가드
+ * 약속이 없는 사용자는 접근 불가
+ * 용도: /missions, /mission/:id 등
+ */
+export const RequireAppointment = ({ children }: { children: ReactNode }) => {
+  const appointmentId = localStorage.getItem('appointmentId');
+
+  // appointmentId가 없거나 유효하지 않으면 /feed로 리다이렉트
+  if (!appointmentId || appointmentId === 'null' || appointmentId === 'undefined') {
+    console.warn('⚠️ [RequireAppointment] 약속이 없는 유저 -> /feed로 리다이렉트');
+    return <Navigate to="/feed" replace />;
+  }
+
+  return <>{children}</>;
+};
+
+/**
+ * 온보딩 완료 필수 라우트 가드
+ * 온보딩을 완료하지 않은 사용자는 접근 불가
+ * 단, 예정된 약속이 있는 경우는 예외 (피드/마이페이지 접근 허용)
+ * 용도: /feed, /mypage 등 메인 기능
+ */
+export const RequireOnboarded = ({ children }: { children: ReactNode }) => {
+  const onboardingComplete = localStorage.getItem('onboarding_complete');
+  const appointmentId = localStorage.getItem('appointmentId');
+
+  // 예정된 약속이 있으면 온보딩 완료 여부와 관계없이 접근 허용
+  if (appointmentId && appointmentId !== 'null' && appointmentId !== 'undefined') {
+    console.log('✅ [RequireOnboarded] 약속이 있는 유저 -> 접근 허용');
+    return <>{children}</>;
+  }
+
+  // 약속이 없고 온보딩도 미완료 -> /chat로 리다이렉트
+  if (onboardingComplete !== 'true') {
+    console.warn('⚠️ [RequireOnboarded] 온보딩 미완료 유저 -> /chat로 리다이렉트');
+    return <Navigate to="/chat" replace />;
+  }
+
+  return <>{children}</>;
+};
+
+/**
+ * 글로벌 리다이렉트 로직
+ * 앱 최초 진입 시 사용자 상태에 따라 적절한 페이지로 이동
+ */
+export const SmartRedirect = () => {
+  const token = localStorage.getItem('token');
+  const appointmentId = localStorage.getItem('appointmentId');
+  const onboardingComplete = localStorage.getItem('onboarding_complete');
+  const userLocation = localStorage.getItem('user_location');
+
+  console.log('=== SmartRedirect 체크 ===');
+  console.log('토큰:', !!token);
+  console.log('약속 ID:', appointmentId);
+  console.log('온보딩 완료:', onboardingComplete === 'true');
+  console.log('위치 설정:', !!userLocation);
+
+  // 1. 토큰 없음 -> 로그인 페이지
+  if (!token || token === 'null' || token === 'undefined') {
+    console.log('🚫 토큰 없음 -> /login');
+    return <Navigate to="/login" replace />;
+  }
+
+  // 2. 약속 있음 -> 미션 상세 페이지 (최우선!)
+  if (appointmentId && appointmentId !== 'null' && appointmentId !== 'undefined') {
+    console.log('🎯 약속 있음 -> /mission으로 "납치"');
+    return <Navigate to={`/mission/${appointmentId}`} replace />;
+  }
+
+  // 3. 온보딩 미완료 -> 온보딩 채팅
+  if (onboardingComplete !== 'true') {
+    console.log('📝 온보딩 미완료 -> /chat');
+    return <Navigate to="/chat" replace />;
+  }
+
+  // 4. 위치 미설정 -> 위치 설정 페이지
+  if (!userLocation) {
+    console.log('📍 위치 미설정 -> /location');
+    return <Navigate to="/location" replace />;
+  }
+
+  // 5. 모든 조건 만족 -> 피드
+  console.log('✅ 기본 진입 -> /feed');
+  return <Navigate to="/feed" replace />;
+};

--- a/frontend/src/utils/toast.ts
+++ b/frontend/src/utils/toast.ts
@@ -1,0 +1,25 @@
+// Simple toast notification utility
+export const showToast = (message: string, duration: number = 3000) => {
+  // Remove any existing toast
+  const existingToast = document.getElementById('custom-toast');
+  if (existingToast) {
+    existingToast.remove();
+  }
+
+  // Create toast element
+  const toast = document.createElement('div');
+  toast.id = 'custom-toast';
+  toast.className = 'fixed bottom-24 left-1/2 transform -translate-x-1/2 bg-charcoal-soft/95 backdrop-blur-lg text-off-white px-6 py-4 rounded-2xl shadow-lg border border-charcoal-lighter z-[100] animate-slide-up';
+  toast.textContent = message;
+
+  // Add to DOM
+  document.body.appendChild(toast);
+
+  // Remove after duration
+  setTimeout(() => {
+    toast.style.opacity = '0';
+    toast.style.transform = 'translate(-50%, 20px)';
+    toast.style.transition = 'all 0.3s ease-out';
+    setTimeout(() => toast.remove(), 300);
+  }, duration);
+};

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -6,5 +6,6 @@ export default defineConfig({
   plugins: [react()],
   server: {
     host: true, // Listen on all local IPs
+    allowedHosts: ['garrett-unmaniacal-raelyn.ngrok-free.dev'],
   },
 })


### PR DESCRIPTION
feat: 피드 상태 영속화, 네비게이션 개선 및 UI/UX 최적화

## 주요 기능 추가

### 1. 피드 상태 영속화 (Like/Save)
- 좋아요 및 저장 상태가 페이지 새로고침 후에도 유지되도록 백엔드 영속화 구현
- Backend:
  - LikedAppointment 엔티티 및 Repository 추가
  - SavedAppointment 엔티티 및 Repository 추가
  - FeedResponse DTO에 isLikedByMe, isSavedByMe 필드 추가
  - AppointmentController에 /like, /save 엔드포인트 추가
  - AppointmentService에서 사용자별 좋아요/저장 상태 조회 로직 구현
- Frontend:
  - EscLikeButton을 controlled component로 리팩토링
  - FeedPage에서 optimistic update 패턴 적용
  - 좋아요/저장 API 연동 및 에러 핸들링 구현
  - 피드 헤더에 "내 약속" 버튼 추가 (→ /appointments)

### 2. 네비게이션 및 라우팅 개선
- MissionDetail 페이지를 MainLayout 내부로 이동 (bottom navigation 표시)
- 리스트 항목 클릭 시 올바른 상세 페이지로 이동하도록 수정:
  - Appointments: /chat/:id → /mission/:id
  - SavedAppointments: TODO 주석 → /mission/:id 네비게이션 구현
- 뒤로가기 버튼 로직 개선:
  - 기존: 하드코딩된 /mypage로 이동
  - 개선: location.state?.from 또는 navigate(-1) 사용
- 에러/완료 후 리다이렉트 경로 수정: /mypage → /appointments

### 3. UI/UX 최적화
- Debug Overlay에 토글 버튼 추가 (항상 표시/숨김 가능)
- MainLayout:
  - 상단 배너 제거, FAB(Floating Action Button)으로 대체
  - 진행 중인 약속 알림 버튼 추가 (우측 하단, 티켓 아이콘)
  - 펄스 애니메이션 및 glow 효과 적용
- MissionDetail:
  - 스크롤 방향 감지 기능 추가 (아래로 스크롤 시 버튼 숨김)
  - D-Day 배지 디자인 개선 (버튼처럼 보이지 않도록)
  - bottom navigation을 위한 padding-bottom 추가
- Appointments:
  - 다크 테마(네온 스타일) 전체 적용
  - 상태 배지, 필터 버튼, 로딩 스피너 색상 통일
  - 즐겨찾기/휴지통 기능 UI 개선

### 4. 라우트 가드 개선
- RequireOnboarded: 약속이 있는 사용자는 온보딩 완료 여부와 무관하게 접근 허용
- GlobalRedirectWrapper: 예외 경로에 /appointments, /reviews 추가
- 약속 보유 사용자의 온보딩 페이지 재진입 방지 로직 추가

## 버그 수정
- 리스트에서 과거 약속 클릭 시 현재 약속이 표시되는 버그 수정
- 약속이 있는 사용자가 피드/마이페이지 접근 시 무한 리다이렉트 버그 수정
- 저장한 일탈 클릭 시 아무 동작 하지 않던 문제 해결

## 기술 스택
- Backend: Spring Boot, JPA, PostgreSQL
- Frontend: React, TypeScript, React Router v7, Framer Motion
- 디자인 시스템: Tailwind CSS (커스텀 네온 테마)