### PR TITLE
feat: 추천 엔진과 DevConsole 시뮬레이션을 공통 규칙 기반으로 고도화

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -1,5 +1,6 @@
 HELP.md
 .gradle
+.gradle-user/
 build/
 !gradle/wrapper/gradle-wrapper.jar
 !**/src/main/**/build/

--- a/backend/src/main/java/com/littleescape/api/config/SchedulingConfig.java
+++ b/backend/src/main/java/com/littleescape/api/config/SchedulingConfig.java
@@ -21,3 +21,6 @@ public class SchedulingConfig {
 
 
 
+
+
+

--- a/backend/src/main/java/com/littleescape/api/controller/AdminController.java
+++ b/backend/src/main/java/com/littleescape/api/controller/AdminController.java
@@ -555,6 +555,20 @@ public class AdminController {
                 null,
                 null,
                 List.of("❌ 시뮬레이션 실행 실패: " + e.getMessage()),
+                List.of(new SimulationResponse.StageInfo(
+                        "SIMULATION_ERROR",
+                        "Simulation error",
+                        "RESULT",
+                        0,
+                        0,
+                        List.of(new SimulationResponse.ReasonInfo(
+                                "SIMULATION_EXCEPTION",
+                                0,
+                                0,
+                                e.getMessage()
+                        )),
+                        List.of()
+                )),
                 0, 0, 0, 0,
                 List.of(),
                 List.of()

--- a/backend/src/main/java/com/littleescape/api/controller/AppointmentController.java
+++ b/backend/src/main/java/com/littleescape/api/controller/AppointmentController.java
@@ -45,7 +45,8 @@ public class AppointmentController {
             request.scheduledAt(),
             request.missionId(),
             request.getUserLatitude(),
-            request.getUserLongitude()
+            request.getUserLongitude(),
+            request.searchRadius()
         );
 
         return ResponseEntity

--- a/backend/src/main/java/com/littleescape/api/domain/Appointment.java
+++ b/backend/src/main/java/com/littleescape/api/domain/Appointment.java
@@ -1,6 +1,7 @@
 package com.littleescape.api.domain;
 
 import com.littleescape.api.domain.type.AppointmentStatus;
+import com.littleescape.api.domain.type.RecommendationRadiusPolicy;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -56,7 +57,7 @@ public class Appointment extends BaseTimeEntity {
 
     // 검색 반경 (km)
     @Column(name = "search_radius", nullable = false)
-    private Integer searchRadius = 5;
+    private Integer searchRadius = RecommendationRadiusPolicy.DEFAULT_SEARCH_RADIUS_KM;
 
     @Column(name = "proof_comment", columnDefinition = "TEXT")
     private String proofComment;

--- a/backend/src/main/java/com/littleescape/api/domain/Place.java
+++ b/backend/src/main/java/com/littleescape/api/domain/Place.java
@@ -198,6 +198,25 @@ public class Place extends BaseTimeEntity {
         }
     }
 
+    public void activate() {
+        this.isActive = true;
+    }
+
+    public void updateBasicInfo(String name, String address, String url,
+                                Double latitude, Double longitude,
+                                MissionCategory category, String imageUrl,
+                                Boolean isFree, DataSource dataSource) {
+        this.name = name;
+        this.address = address;
+        this.url = url;
+        this.latitude = latitude;
+        this.longitude = longitude;
+        this.category = category;
+        this.imageUrl = imageUrl;
+        this.isFree = isFree;
+        this.dataSource = dataSource;
+    }
+
     /**
      * 공연 정보 업데이트 (upsert 시 사용)
      * 허브 컬럼 + detail 테이블 동시 업데이트 (dual-write)
@@ -209,6 +228,11 @@ public class Place extends BaseTimeEntity {
         this.ticketPrice = ticketPrice;
         this.startDate = startDate;
         this.endDate = endDate;
+        if (endDate != null && endDate.isBefore(LocalDate.now())) {
+            this.isActive = false;
+        } else {
+            this.isActive = true;
+        }
         if (imageUrl != null) {
             this.imageUrl = imageUrl;
         }

--- a/backend/src/main/java/com/littleescape/api/domain/type/Congestion.java
+++ b/backend/src/main/java/com/littleescape/api/domain/type/Congestion.java
@@ -4,7 +4,7 @@ package com.littleescape.api.domain.type;
  * 혼잡도 수준
  */
 public enum Congestion {
-    LOW,     // 낮음
-    MEDIUM,  // 보통
-    HIGH     // 높음
+    LOW,
+    NORMAL,
+    HIGH
 }

--- a/backend/src/main/java/com/littleescape/api/domain/type/RecommendationRadiusPolicy.java
+++ b/backend/src/main/java/com/littleescape/api/domain/type/RecommendationRadiusPolicy.java
@@ -1,0 +1,16 @@
+package com.littleescape.api.domain.type;
+
+public final class RecommendationRadiusPolicy {
+
+    public static final int DEFAULT_SEARCH_RADIUS_KM = 10;
+
+    private RecommendationRadiusPolicy() {
+    }
+
+    public static int resolveSearchRadius(Integer searchRadius) {
+        if (searchRadius == null || searchRadius <= 0) {
+            return DEFAULT_SEARCH_RADIUS_KM;
+        }
+        return searchRadius;
+    }
+}

--- a/backend/src/main/java/com/littleescape/api/dto/AppointmentCreateRequest.java
+++ b/backend/src/main/java/com/littleescape/api/dto/AppointmentCreateRequest.java
@@ -5,13 +5,13 @@ import jakarta.validation.constraints.NotNull;
 import java.time.LocalDateTime;
 
 public record AppointmentCreateRequest(
-    @NotNull(message = "약속 시간은 필수입니다")
-    LocalDateTime scheduledAt,
-    Long missionId,  // 선택적 필드 (null 가능)
-    Double userLatitude,  // 사용자 위도 (null이면 기본값 사용)
-    Double userLongitude  // 사용자 경도 (null이면 기본값 사용)
+        @NotNull(message = "약속 시간은 필수입니다.")
+        LocalDateTime scheduledAt,
+        Long missionId,
+        Double userLatitude,
+        Double userLongitude,
+        Integer searchRadius
 ) {
-    // 기본 위치: 서울 성수동 (37.544, 127.056)
     private static final Double DEFAULT_LATITUDE = 37.544;
     private static final Double DEFAULT_LONGITUDE = 127.056;
 

--- a/backend/src/main/java/com/littleescape/api/dto/UserPreferencesDto.java
+++ b/backend/src/main/java/com/littleescape/api/dto/UserPreferencesDto.java
@@ -15,3 +15,6 @@ public record UserPreferencesDto(
 
 
 
+
+
+

--- a/backend/src/main/java/com/littleescape/api/dto/ingestion/KakaoGeoResponse.java
+++ b/backend/src/main/java/com/littleescape/api/dto/ingestion/KakaoGeoResponse.java
@@ -120,3 +120,6 @@ public class KakaoGeoResponse {
 
 
 
+
+
+

--- a/backend/src/main/java/com/littleescape/api/dto/ingestion/KopisResponse.java
+++ b/backend/src/main/java/com/littleescape/api/dto/ingestion/KopisResponse.java
@@ -61,3 +61,6 @@ public class KopisResponse {
 
 
 
+
+
+

--- a/backend/src/main/java/com/littleescape/api/dto/ingestion/LibraryResponse.java
+++ b/backend/src/main/java/com/littleescape/api/dto/ingestion/LibraryResponse.java
@@ -78,3 +78,6 @@ public class LibraryResponse {
 
 
 
+
+
+

--- a/backend/src/main/java/com/littleescape/api/dto/ingestion/SeoulEventResponse.java
+++ b/backend/src/main/java/com/littleescape/api/dto/ingestion/SeoulEventResponse.java
@@ -117,3 +117,6 @@ public class SeoulEventResponse {
 
 
 
+
+
+

--- a/backend/src/main/java/com/littleescape/api/dto/ingestion/SeoulRestaurantResponse.java
+++ b/backend/src/main/java/com/littleescape/api/dto/ingestion/SeoulRestaurantResponse.java
@@ -174,3 +174,6 @@ public class SeoulRestaurantResponse {
 
 
 
+
+
+

--- a/backend/src/main/java/com/littleescape/api/dto/simulation/SimulationRequest.java
+++ b/backend/src/main/java/com/littleescape/api/dto/simulation/SimulationRequest.java
@@ -3,59 +3,61 @@ package com.littleescape.api.dto.simulation;
 import com.littleescape.api.domain.type.AirQuality;
 import com.littleescape.api.domain.type.Congestion;
 import com.littleescape.api.domain.type.MissionCategory;
+import com.littleescape.api.domain.type.RecommendationRadiusPolicy;
 import com.littleescape.api.domain.type.Weather;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.time.LocalDateTime;
 
-/**
- * God Mode Simulation 요청 DTO
- * 모든 환경 변수를 통제하여 추천 로직을 테스트
- */
-@Schema(description = "시뮬레이션 요청 - 모든 환경 변수를 통제")
+@Schema(description = "Simulation request payload")
 public record SimulationRequest(
 
-    @Schema(description = "가상의 현재 시간 (요일/시간대 체크용)", example = "2025-01-20T14:30:00")
+    @Schema(description = "Simulation target date/time", example = "2025-01-20T14:30:00")
     LocalDateTime targetDateTime,
 
-    @Schema(description = "사용자 위도", example = "37.5665")
+    @Schema(description = "User latitude", example = "37.5665")
     Double latitude,
 
-    @Schema(description = "사용자 경도", example = "126.9780")
+    @Schema(description = "User longitude", example = "126.9780")
     Double longitude,
 
-    @Schema(description = "탐색 반경 (km)", example = "10")
+    @Schema(description = "Search radius in km", example = "10")
     Integer searchRadius,
 
-    @Schema(description = "날씨 상태", example = "SUNNY")
+    @Schema(description = "Weather", example = "SUNNY")
     Weather weather,
 
-    @Schema(description = "기온 (°C)", example = "15.5")
+    @Schema(description = "Temperature in Celsius", example = "15.5")
     Double temperature,
 
-    @Schema(description = "공기 질 / 미세먼지", example = "GOOD")
+    @Schema(description = "Air quality", example = "GOOD")
     AirQuality airQuality,
 
-    @Schema(description = "혼잡도", example = "LOW")
+    @Schema(description = "Congestion level", example = "NORMAL")
     Congestion congestion,
 
-    @Schema(description = "사용자 MBTI (I or E)", example = "I")
+    @Schema(description = "User MBTI (I or E)", example = "I")
     String userMbti,
 
-    @Schema(description = "특정 카테고리 강제 지정 (선택 사항)", example = "FOOD", nullable = true)
+    @Schema(description = "Optional user ID for loading saved/liked/completed preference signals", example = "12", nullable = true)
+    Long userId,
+
+    @Schema(
+            description = "Comma-separated user constraint tags",
+            example = "NO_ALCOHOL,HATE_WALKING",
+            nullable = true
+    )
+    String userTags,
+
+    @Schema(description = "Force mission category", example = "FOOD", nullable = true)
     MissionCategory forcedCategory
 ) {
 
-    /**
-     * 기본값 검증 및 설정
-     */
     public SimulationRequest {
         if (targetDateTime == null) {
             targetDateTime = LocalDateTime.now();
         }
-        if (searchRadius == null || searchRadius <= 0) {
-            searchRadius = 10;
-        }
+        searchRadius = RecommendationRadiusPolicy.resolveSearchRadius(searchRadius);
         if (weather == null) {
             weather = Weather.SUNNY;
         }
@@ -66,7 +68,10 @@ public record SimulationRequest(
             airQuality = AirQuality.GOOD;
         }
         if (congestion == null) {
-            congestion = Congestion.LOW;
+            congestion = Congestion.NORMAL;
+        }
+        if (userTags != null && userTags.isBlank()) {
+            userTags = null;
         }
     }
 }

--- a/backend/src/main/java/com/littleescape/api/dto/simulation/SimulationResponse.java
+++ b/backend/src/main/java/com/littleescape/api/dto/simulation/SimulationResponse.java
@@ -25,6 +25,9 @@ public record SimulationResponse(
     @Schema(description = "디버그 로그 - 필터링/추천 과정 설명")
     List<String> debugLogs,
 
+    @Schema(description = "Structured stage-by-stage simulation trace")
+    List<StageInfo> stages,
+
     @Schema(description = "총 검색된 미션 후보 개수")
     Integer totalMissionCandidates,
 
@@ -43,6 +46,37 @@ public record SimulationResponse(
     @Schema(description = "필터링 후 전체 장소 목록")
     List<PlaceInfo> allFilteredPlaces
 ) {
+
+    @Schema(description = "Stage-level structured debug info")
+    public record StageInfo(
+        String code,
+        String label,
+        String targetType,
+        Integer beforeCount,
+        Integer afterCount,
+        List<ReasonInfo> reasons,
+        List<SelectionInfo> selections
+    ) {
+    }
+
+    @Schema(description = "Structured exclusion or transition reason")
+    public record ReasonInfo(
+        String code,
+        Integer beforeCount,
+        Integer afterCount,
+        String detail
+    ) {
+    }
+
+    @Schema(description = "Final selected entity info")
+    public record SelectionInfo(
+        String type,
+        Long id,
+        String name,
+        String category,
+        String detail
+    ) {
+    }
 
     /**
      * 공연/축제 상세 정보

--- a/backend/src/main/java/com/littleescape/api/repository/AppointmentRepository.java
+++ b/backend/src/main/java/com/littleescape/api/repository/AppointmentRepository.java
@@ -13,69 +13,56 @@ import java.util.List;
 
 public interface AppointmentRepository extends JpaRepository<Appointment, Long> {
     List<Appointment> findByUserId(Long userId);
-    
-    // 사용자의 약속을 예정일 기준 내림차순으로 조회 (DB 정렬)
+
     List<Appointment> findAllByUserIdOrderByScheduledAtDesc(Long userId);
-    
+
     Long countByUserIdAndMissionTemplateId(Long userId, Long missionTemplateId);
+
     boolean existsByUserIdAndStatusIn(Long userId, List<AppointmentStatus> statuses);
 
-    // 특정 시간 범위 사이에 있는 약속 조회
     List<Appointment> findAllByScheduledAtBetween(LocalDateTime start, LocalDateTime end);
 
     List<Appointment> findAllByStatusAndScheduledAtBetween(
-        AppointmentStatus status,
-        LocalDateTime start,
-        LocalDateTime end
+            AppointmentStatus status,
+            LocalDateTime start,
+            LocalDateTime end
     );
 
-    // UUID 토큰으로 조회
     java.util.Optional<Appointment> findByUnlockToken(String unlockToken);
 
     void deleteByUserId(Long userId);
 
-    // 피드용: 공개된 완료 약속을 최신순으로 조회 (페이징 지원)
     List<Appointment> findAllByStatusAndIsPublicTrueOrderByCompletedAtDesc(
-        AppointmentStatus status,
-        Pageable pageable
+            AppointmentStatus status,
+            Pageable pageable
     );
 
-    // 피드용 (확장): 공개된 약속을 여러 상태로 조회 (SCHEDULED, ARRIVED, COMPLETED)
     List<Appointment> findAllByStatusInAndIsPublicTrueOrderByUpdatedAtDesc(
-        List<AppointmentStatus> statuses,
-        Pageable pageable
+            List<AppointmentStatus> statuses,
+            Pageable pageable
     );
 
-    // 만료 처리용: 특정 상태이면서 예정 시간이 지난 약속들을 배치 업데이트
     @Modifying
     @Query("UPDATE Appointment a SET a.status = :newStatus " +
            "WHERE a.status IN :currentStatuses " +
            "AND a.scheduledAt < :expirationTime")
     int updateExpiredAppointments(
-        @Param("newStatus") AppointmentStatus newStatus,
-        @Param("currentStatuses") List<AppointmentStatus> currentStatuses,
-        @Param("expirationTime") LocalDateTime expirationTime
+            @Param("newStatus") AppointmentStatus newStatus,
+            @Param("currentStatuses") List<AppointmentStatus> currentStatuses,
+            @Param("expirationTime") LocalDateTime expirationTime
     );
 
-    /**
-     * D-1 미션 공개 대상 약속 조회
-     * 조건: 미션 미공개(isMissionRevealed=false) + 예정일이 24시간 이내
-     */
     @Query("SELECT a FROM Appointment a " +
            "WHERE a.isMissionRevealed = false " +
            "AND a.missionTemplate IS NOT NULL " +
            "AND a.status IN :activeStatuses " +
            "AND a.scheduledAt BETWEEN :now AND :tomorrow")
     List<Appointment> findMissionRevealTargets(
-        @Param("activeStatuses") List<AppointmentStatus> activeStatuses,
-        @Param("now") LocalDateTime now,
-        @Param("tomorrow") LocalDateTime tomorrow
+            @Param("activeStatuses") List<AppointmentStatus> activeStatuses,
+            @Param("now") LocalDateTime now,
+            @Param("tomorrow") LocalDateTime tomorrow
     );
 
-    /**
-     * D-1 미션 공개 배치 처리
-     * 예정일이 24시간 이내인 약속들의 미션을 일괄 공개
-     */
     @Modifying
     @Query("UPDATE Appointment a SET a.isMissionRevealed = true " +
            "WHERE a.isMissionRevealed = false " +
@@ -83,8 +70,34 @@ public interface AppointmentRepository extends JpaRepository<Appointment, Long> 
            "AND a.status IN :activeStatuses " +
            "AND a.scheduledAt BETWEEN :now AND :tomorrow")
     int revealMissionsForD1(
-        @Param("activeStatuses") List<AppointmentStatus> activeStatuses,
-        @Param("now") LocalDateTime now,
-        @Param("tomorrow") LocalDateTime tomorrow
+            @Param("activeStatuses") List<AppointmentStatus> activeStatuses,
+            @Param("now") LocalDateTime now,
+            @Param("tomorrow") LocalDateTime tomorrow
+    );
+
+    @Query("""
+        SELECT mt.category as category, COUNT(a.id) as count
+        FROM Appointment a
+        JOIN a.missionTemplate mt
+        WHERE a.user.id = :userId
+          AND a.status IN :statuses
+        GROUP BY mt.category
+        """)
+    List<Object[]> findCategoryStatsByUserIdAndStatuses(
+            @Param("userId") Long userId,
+            @Param("statuses") List<AppointmentStatus> statuses
+    );
+
+    @Query("""
+        SELECT p.dataSource as dataSource, COUNT(a.id) as count
+        FROM Appointment a
+        JOIN a.place p
+        WHERE a.user.id = :userId
+          AND a.status IN :statuses
+        GROUP BY p.dataSource
+        """)
+    List<Object[]> findPlaceDataSourceStatsByUserIdAndStatuses(
+            @Param("userId") Long userId,
+            @Param("statuses") List<AppointmentStatus> statuses
     );
 }

--- a/backend/src/main/java/com/littleescape/api/repository/LikedAppointmentRepository.java
+++ b/backend/src/main/java/com/littleescape/api/repository/LikedAppointmentRepository.java
@@ -2,30 +2,45 @@ package com.littleescape.api.repository;
 
 import com.littleescape.api.domain.LikedAppointment;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
 
 public interface LikedAppointmentRepository extends JpaRepository<LikedAppointment, Long> {
 
-    // 특정 사용자와 약속의 좋아요 여부 확인
     boolean existsByUserIdAndAppointmentId(Long userId, Long appointmentId);
 
-    // 특정 사용자와 약속의 좋아요 레코드 조회
     Optional<LikedAppointment> findByUserIdAndAppointmentId(Long userId, Long appointmentId);
 
-    // 특정 사용자가 좋아요한 모든 약속 조회
     List<LikedAppointment> findAllByUserIdOrderByCreatedAtDesc(Long userId);
 
-    // 좋아요 개수 조회
     Long countByUserId(Long userId);
 
-    // 특정 약속의 좋아요 개수
     Long countByAppointmentId(Long appointmentId);
 
-    // 사용자 삭제 시 좋아요 레코드도 함께 삭제
+    @Query("""
+        SELECT mt.category as category, COUNT(la.id) as count
+        FROM LikedAppointment la
+        JOIN la.appointment a
+        JOIN a.missionTemplate mt
+        WHERE la.user.id = :userId
+        GROUP BY mt.category
+        """)
+    List<Object[]> findCategoryStatsByUserId(@Param("userId") Long userId);
+
+    @Query("""
+        SELECT p.dataSource as dataSource, COUNT(la.id) as count
+        FROM LikedAppointment la
+        JOIN la.appointment a
+        JOIN a.place p
+        WHERE la.user.id = :userId
+        GROUP BY p.dataSource
+        """)
+    List<Object[]> findPlaceDataSourceStatsByUserId(@Param("userId") Long userId);
+
     void deleteByUserId(Long userId);
 
-    // 약속 삭제 시 해당 약속을 좋아요한 모든 레코드 삭제
     void deleteByAppointmentId(Long appointmentId);
 }

--- a/backend/src/main/java/com/littleescape/api/repository/PlaceRepository.java
+++ b/backend/src/main/java/com/littleescape/api/repository/PlaceRepository.java
@@ -3,6 +3,7 @@ package com.littleescape.api.repository;
 import com.littleescape.api.domain.Place;
 import com.littleescape.api.domain.type.DataSource;
 import com.littleescape.api.domain.type.MissionCategory;
+import com.littleescape.api.domain.type.RecommendationRadiusPolicy;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -13,6 +14,8 @@ import java.util.List;
 import java.util.Optional;
 
 public interface PlaceRepository extends JpaRepository<Place, Long> {
+    int DEFAULT_DISTANCE_RADIUS_KM = RecommendationRadiusPolicy.DEFAULT_SEARCH_RADIUS_KM;
+
     List<Place> findByCategory(MissionCategory category);
 
     /**
@@ -99,19 +102,20 @@ public interface PlaceRepository extends JpaRepository<Place, Long> {
             "LEFT JOIN FETCH p.facilityDetail " +
             "WHERE p.category = :category AND " +
             "p.isActive = true AND " +
-            "ABS(p.latitude - :userLat) <= 0.1 AND " +
-            "ABS(p.longitude - :userLon) <= 0.1 AND " +
+            "ABS(p.latitude - :userLat) <= (:radiusKm / 111.0) AND " +
+            "ABS(p.longitude - :userLon) <= (:radiusKm / (111.0 * cos(radians(:userLat)))) AND " +
             "(6371 * acos(cos(radians(:userLat)) * cos(radians(p.latitude)) * " +
             "cos(radians(p.longitude) - radians(:userLon)) + " +
-            "sin(radians(:userLat)) * sin(radians(p.latitude)))) <= 10 AND " +
+            "sin(radians(:userLat)) * sin(radians(p.latitude)))) <= :radiusKm AND " +
             "p.name NOT LIKE %:keyword1% AND p.name NOT LIKE %:keyword2% AND " +
             "p.name NOT LIKE %:keyword3% AND p.name NOT LIKE %:keyword4% AND " +
             "p.name NOT LIKE %:keyword5% AND p.name NOT LIKE %:keyword6% AND " +
             "p.name NOT LIKE %:keyword7%")
-    List<Place> findByCategoryFilteredWithDistance(
+    List<Place> findByCategoryFilteredWithDistanceAndRadius(
             @Param("category") MissionCategory category,
             @Param("userLat") Double userLatitude,
             @Param("userLon") Double userLongitude,
+            @Param("radiusKm") Integer radiusKm,
             @Param("keyword1") String keyword1,
             @Param("keyword2") String keyword2,
             @Param("keyword3") String keyword3,
@@ -120,6 +124,33 @@ public interface PlaceRepository extends JpaRepository<Place, Long> {
             @Param("keyword6") String keyword6,
             @Param("keyword7") String keyword7
     );
+
+    default List<Place> findByCategoryFilteredWithDistance(
+            MissionCategory category,
+            Double userLatitude,
+            Double userLongitude,
+            String keyword1,
+            String keyword2,
+            String keyword3,
+            String keyword4,
+            String keyword5,
+            String keyword6,
+            String keyword7
+    ) {
+        return findByCategoryFilteredWithDistanceAndRadius(
+                category,
+                userLatitude,
+                userLongitude,
+                DEFAULT_DISTANCE_RADIUS_KM,
+                keyword1,
+                keyword2,
+                keyword3,
+                keyword4,
+                keyword5,
+                keyword6,
+                keyword7
+        );
+    }
 
     /**
      * 필터링된 양질의 장소 조회 (카테고리 무관 fallback + 거리 제한)
@@ -130,18 +161,19 @@ public interface PlaceRepository extends JpaRepository<Place, Long> {
             "LEFT JOIN FETCH p.facilityDetail " +
             "WHERE " +
             "p.isActive = true AND " +
-            "ABS(p.latitude - :userLat) <= 0.1 AND " +
-            "ABS(p.longitude - :userLon) <= 0.1 AND " +
+            "ABS(p.latitude - :userLat) <= (:radiusKm / 111.0) AND " +
+            "ABS(p.longitude - :userLon) <= (:radiusKm / (111.0 * cos(radians(:userLat)))) AND " +
             "(6371 * acos(cos(radians(:userLat)) * cos(radians(p.latitude)) * " +
             "cos(radians(p.longitude) - radians(:userLon)) + " +
-            "sin(radians(:userLat)) * sin(radians(p.latitude)))) <= 10 AND " +
+            "sin(radians(:userLat)) * sin(radians(p.latitude)))) <= :radiusKm AND " +
             "p.name NOT LIKE %:keyword1% AND p.name NOT LIKE %:keyword2% AND " +
             "p.name NOT LIKE %:keyword3% AND p.name NOT LIKE %:keyword4% AND " +
             "p.name NOT LIKE %:keyword5% AND p.name NOT LIKE %:keyword6% AND " +
             "p.name NOT LIKE %:keyword7%")
-    List<Place> findAllFilteredWithDistance(
+    List<Place> findAllFilteredWithDistanceAndRadius(
             @Param("userLat") Double userLatitude,
             @Param("userLon") Double userLongitude,
+            @Param("radiusKm") Integer radiusKm,
             @Param("keyword1") String keyword1,
             @Param("keyword2") String keyword2,
             @Param("keyword3") String keyword3,
@@ -150,6 +182,31 @@ public interface PlaceRepository extends JpaRepository<Place, Long> {
             @Param("keyword6") String keyword6,
             @Param("keyword7") String keyword7
     );
+
+    default List<Place> findAllFilteredWithDistance(
+            Double userLatitude,
+            Double userLongitude,
+            String keyword1,
+            String keyword2,
+            String keyword3,
+            String keyword4,
+            String keyword5,
+            String keyword6,
+            String keyword7
+    ) {
+        return findAllFilteredWithDistanceAndRadius(
+                userLatitude,
+                userLongitude,
+                DEFAULT_DISTANCE_RADIUS_KM,
+                keyword1,
+                keyword2,
+                keyword3,
+                keyword4,
+                keyword5,
+                keyword6,
+                keyword7
+        );
+    }
 
     /**
      * 카테고리별 + 거리 제한 장소 조회 (키워드 필터링 없음)
@@ -160,16 +217,30 @@ public interface PlaceRepository extends JpaRepository<Place, Long> {
             "LEFT JOIN FETCH p.facilityDetail " +
             "WHERE p.category = :category AND " +
             "p.isActive = true AND " +
-            "ABS(p.latitude - :userLat) <= 0.1 AND " +
-            "ABS(p.longitude - :userLon) <= 0.1 AND " +
+            "ABS(p.latitude - :userLat) <= (:radiusKm / 111.0) AND " +
+            "ABS(p.longitude - :userLon) <= (:radiusKm / (111.0 * cos(radians(:userLat)))) AND " +
             "(6371 * acos(cos(radians(:userLat)) * cos(radians(p.latitude)) * " +
             "cos(radians(p.longitude) - radians(:userLon)) + " +
-            "sin(radians(:userLat)) * sin(radians(p.latitude)))) <= 10")
-    List<Place> findByCategoryWithDistance(
+            "sin(radians(:userLat)) * sin(radians(p.latitude)))) <= :radiusKm")
+    List<Place> findByCategoryWithDistanceAndRadius(
             @Param("category") MissionCategory category,
             @Param("userLat") Double userLatitude,
-            @Param("userLon") Double userLongitude
+            @Param("userLon") Double userLongitude,
+            @Param("radiusKm") Integer radiusKm
     );
+
+    default List<Place> findByCategoryWithDistance(
+            MissionCategory category,
+            Double userLatitude,
+            Double userLongitude
+    ) {
+        return findByCategoryWithDistanceAndRadius(
+                category,
+                userLatitude,
+                userLongitude,
+                DEFAULT_DISTANCE_RADIUS_KM
+        );
+    }
 
     /**
      * 전체 장소 + 거리 제한 조회 (키워드 필터링 없음)
@@ -179,15 +250,27 @@ public interface PlaceRepository extends JpaRepository<Place, Long> {
             "LEFT JOIN FETCH p.performanceDetail " +
             "LEFT JOIN FETCH p.facilityDetail " +
             "WHERE p.isActive = true AND " +
-            "ABS(p.latitude - :userLat) <= 0.1 AND " +
-            "ABS(p.longitude - :userLon) <= 0.1 AND " +
+            "ABS(p.latitude - :userLat) <= (:radiusKm / 111.0) AND " +
+            "ABS(p.longitude - :userLon) <= (:radiusKm / (111.0 * cos(radians(:userLat)))) AND " +
             "(6371 * acos(cos(radians(:userLat)) * cos(radians(p.latitude)) * " +
             "cos(radians(p.longitude) - radians(:userLon)) + " +
-            "sin(radians(:userLat)) * sin(radians(p.latitude)))) <= 10")
-    List<Place> findAllWithDistance(
+            "sin(radians(:userLat)) * sin(radians(p.latitude)))) <= :radiusKm")
+    List<Place> findAllWithDistanceAndRadius(
             @Param("userLat") Double userLatitude,
-            @Param("userLon") Double userLongitude
+            @Param("userLon") Double userLongitude,
+            @Param("radiusKm") Integer radiusKm
     );
+
+    default List<Place> findAllWithDistance(
+            Double userLatitude,
+            Double userLongitude
+    ) {
+        return findAllWithDistanceAndRadius(
+                userLatitude,
+                userLongitude,
+                DEFAULT_DISTANCE_RADIUS_KM
+        );
+    }
 
     // ========== 신규 메서드 (데이터 수집용) ==========
 

--- a/backend/src/main/java/com/littleescape/api/repository/SavedAppointmentRepository.java
+++ b/backend/src/main/java/com/littleescape/api/repository/SavedAppointmentRepository.java
@@ -1,39 +1,25 @@
 package com.littleescape.api.repository;
 
 import com.littleescape.api.domain.SavedAppointment;
-import com.littleescape.api.domain.type.MissionCategory;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 
 public interface SavedAppointmentRepository extends JpaRepository<SavedAppointment, Long> {
 
-    // 특정 사용자와 약속의 저장 여부 확인
     boolean existsByUserIdAndAppointmentId(Long userId, Long appointmentId);
 
-    // 특정 사용자와 약속의 저장 레코드 조회
     Optional<SavedAppointment> findByUserIdAndAppointmentId(Long userId, Long appointmentId);
 
-    // 특정 사용자가 저장한 모든 약속 조회 (최신순)
     List<SavedAppointment> findAllByUserIdOrderByCreatedAtDesc(Long userId);
 
-    // 저장 개수 조회
     Long countByUserId(Long userId);
 
-    // 특정 약속의 저장 개수 조회
     Long countByAppointmentId(Long appointmentId);
 
-    /**
-     * 사용자가 저장한 약속들의 카테고리별 통계 조회
-     * 추천 알고리즘에서 가중치 계산에 사용
-     *
-     * @param userId 사용자 ID
-     * @return 카테고리별 저장 횟수 (Map<Category, Count>)
-     */
     @Query("""
         SELECT mt.category as category, COUNT(sa.id) as count
         FROM SavedAppointment sa
@@ -44,13 +30,17 @@ public interface SavedAppointmentRepository extends JpaRepository<SavedAppointme
         """)
     List<Object[]> findCategoryStatsByUserId(@Param("userId") Long userId);
 
-    /**
-     * 사용자 삭제 시 저장 레코드도 함께 삭제
-     */
+    @Query("""
+        SELECT p.dataSource as dataSource, COUNT(sa.id) as count
+        FROM SavedAppointment sa
+        JOIN sa.appointment a
+        JOIN a.place p
+        WHERE sa.user.id = :userId
+        GROUP BY p.dataSource
+        """)
+    List<Object[]> findPlaceDataSourceStatsByUserId(@Param("userId") Long userId);
+
     void deleteByUserId(Long userId);
 
-    /**
-     * 약속 삭제 시 해당 약속을 저장한 모든 레코드 삭제
-     */
     void deleteByAppointmentId(Long appointmentId);
 }

--- a/backend/src/main/java/com/littleescape/api/service/AppointmentService.java
+++ b/backend/src/main/java/com/littleescape/api/service/AppointmentService.java
@@ -13,6 +13,7 @@ import com.littleescape.api.repository.AppointmentRepository;
 import com.littleescape.api.repository.MissionTemplateRepository;
 import com.littleescape.api.repository.PlaceRepository;
 import com.littleescape.api.repository.UserRepository;
+import com.littleescape.api.service.simulation.EnvironmentContext;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.PageRequest;
@@ -20,13 +21,11 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
-import java.util.Set;
-import java.util.HashSet;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 @Service
@@ -41,214 +40,204 @@ public class AppointmentService {
     private final com.littleescape.api.repository.SavedAppointmentRepository savedAppointmentRepository;
     private final com.littleescape.api.repository.LikedAppointmentRepository likedAppointmentRepository;
     private final com.littleescape.api.repository.CommentRepository commentRepository;
+    private final RecommendationTagConflictService recommendationTagConflictService;
+    private final RecommendationSupportService recommendationSupportService;
+    private final PlaceScheduleFilterService placeScheduleFilterService;
+    private final PlaceRecommendationScoringService placeRecommendationScoringService;
+    private final RecommendationEnvironmentService recommendationEnvironmentService;
+    private final RecommendationPreferenceService recommendationPreferenceService;
+    private final MissionRecommendationSelectionService missionRecommendationSelectionService;
 
-    // 1인 가구 타겟에 맞지 않는 키워드
+    // Keywords that indicate venues outside the intended single-person recommendation scope.
     private static final String[] BAD_KEYWORDS = {
-        "어린이", "유아", "강좌", "교실", "모집", "시니어", "동호회"
+        "어린이",
+        "유아",
+        "강좌",
+        "교실",
+        "모집",
+        "시니어",
+        "동호회"
     };
 
-    /**
-     * 가중치 기반 미션 선택
-     * 사용자가 저장한 약속의 카테고리를 분석하여 선호 카테고리에 가중치 부여
-     *
-     * @param userId 사용자 ID
-     * @param candidates 미션 후보 리스트
-     * @return 선택된 미션
-     */
-    private MissionTemplate selectMissionWithCategoryWeight(Long userId, List<MissionTemplate> candidates) {
-        // 카테고리별 가중치 조회
-        java.util.Map<com.littleescape.api.domain.type.MissionCategory, Double> weights = getCategoryWeights(userId);
+    private static final int MIN_PLACE_CANDIDATE_POOL = 5;
+    private static final int MAX_RELAXED_RADIUS_KM = 20;
+    private static final int DATA_SOURCE_PER_SOURCE_CAP = 3;
 
-        // 가중치 적용된 후보 리스트 생성
-        List<MissionTemplate> weightedCandidates = new ArrayList<>();
-        for (MissionTemplate mission : candidates) {
-            Double weight = weights.getOrDefault(mission.getCategory(), 1.0);
+    private MissionTemplate selectMissionWithCategoryWeight(
+            List<MissionTemplate> candidates,
+            RecommendationPreferenceService.UserPreferenceProfile preferenceProfile,
+            String stageLabel
+    ) {
+        MissionRecommendationSelectionService.MissionSelectionResult selectionResult =
+                missionRecommendationSelectionService.selectMission(candidates, preferenceProfile);
 
-            // 가중치만큼 리스트에 중복 추가 (예: 가중치 2.0이면 2번 추가)
-            int repeatCount = (int) Math.ceil(weight);
-            for (int i = 0; i < repeatCount; i++) {
-                weightedCandidates.add(mission);
-            }
-        }
+        selectionResult.rankedCandidates().stream()
+                .limit(5)
+                .forEach(candidate -> log.info(
+                        "{} - mission candidate id={}, title={}, category={}, categoryWeight={}",
+                        stageLabel,
+                        candidate.mission().getId(),
+                        candidate.mission().getTitle(),
+                        candidate.mission().getCategory(),
+                        candidate.categoryWeight()
+                ));
 
-        log.info("가중치 적용 전 후보: {}개 → 적용 후: {}개",
-                candidates.size(), weightedCandidates.size());
-
-        // 가중치 적용된 리스트에서 랜덤 선택
-        Collections.shuffle(weightedCandidates);
-        return weightedCandidates.get(0);
-    }
-
-    /**
-     * 태그 충돌 검증 메서드
-     * 사용자 태그와 미션/장소 태그를 비교하여 충돌 여부 반환
-     *
-     * @param userTags 사용자 태그 (쉼표로 구분된 문자열, 예: "NO_ALCOHOL,HATE_WALKING")
-     * @param targetTags 미션/장소 태그 (쉼표로 구분된 문자열, 예: "ALCOHOL_ONLY,HIGH_ACTIVITY")
-     * @return true면 충돌 (추천 제외), false면 충돌 없음 (추천 가능)
-     */
-    private boolean hasTagConflict(String userTags, String targetTags) {
-        if (userTags == null || userTags.trim().isEmpty()
-            || targetTags == null || targetTags.trim().isEmpty()) {
-            return false; // 태그가 없으면 충돌 없음
-        }
-
-        Set<String> userTagSet = Arrays.stream(userTags.split(","))
-                .map(String::trim)
-                .collect(Collectors.toSet());
-
-        Set<String> targetTagSet = Arrays.stream(targetTags.split(","))
-                .map(String::trim)
-                .collect(Collectors.toSet());
-
-        // 충돌 규칙 정의
-        // 1. 유저가 NO_ALCOHOL && 장소/미션이 ALCOHOL_ONLY -> 충돌
-        if (userTagSet.contains("NO_ALCOHOL") && targetTagSet.contains("ALCOHOL_ONLY")) {
-            log.info("🚫 태그 충돌 감지: 사용자는 NO_ALCOHOL, 대상은 ALCOHOL_ONLY");
-            return true;
-        }
-
-        // 2. 유저가 HATE_WALKING && 미션이 HIGH_ACTIVITY -> 충돌
-        if (userTagSet.contains("HATE_WALKING") && targetTagSet.contains("HIGH_ACTIVITY")) {
-            log.info("🚫 태그 충돌 감지: 사용자는 HATE_WALKING, 대상은 HIGH_ACTIVITY");
-            return true;
-        }
-
-        // 3. 유저가 NO_SPORTS && 미션이 SPORTS_REQUIRED -> 충돌
-        if (userTagSet.contains("NO_SPORTS") && targetTagSet.contains("SPORTS_REQUIRED")) {
-            log.info("🚫 태그 충돌 감지: 사용자는 NO_SPORTS, 대상은 SPORTS_REQUIRED");
-            return true;
-        }
-
-        // 4. 유저가 INDOOR_ONLY && 미션이 OUTDOOR_REQUIRED -> 충돌
-        if (userTagSet.contains("INDOOR_ONLY") && targetTagSet.contains("OUTDOOR_REQUIRED")) {
-            log.info("🚫 태그 충돌 감지: 사용자는 INDOOR_ONLY, 대상은 OUTDOOR_REQUIRED");
-            return true;
-        }
-
-        return false; // 충돌 없음
+        MissionRecommendationSelectionService.MissionCandidateScore selected = selectionResult.selected();
+        log.info(
+                "{} - selected mission id={}, title={}, category={}, selectedPoint={}, totalWeight={}, randomFraction={}",
+                stageLabel,
+                selected.mission().getId(),
+                selected.mission().getTitle(),
+                selected.mission().getCategory(),
+                String.format("%.3f", selectionResult.selectedPoint()),
+                String.format("%.3f", selectionResult.totalWeight()),
+                String.format("%.3f", selectionResult.randomFraction())
+        );
+        return selected.mission();
     }
 
     @Transactional
     public Appointment createAppointment(Long userId, LocalDateTime scheduledAt, Long missionId,
-                                        Double userLatitude, Double userLongitude) {
-        log.info("=== 약속 생성 시작 ===");
-        log.info("사용자 ID: {}, 약속 시간: {}, 미션 ID: {}", userId, scheduledAt, missionId);
-        log.info("사용자 위치: 위도 {}, 경도 {}", userLatitude, userLongitude);
+                                         Double userLatitude, Double userLongitude, Integer searchRadius) {
+        log.info("=== create appointment start ===");
+        log.info("userId={}, scheduledAt={}, missionId={}", userId, scheduledAt, missionId);
+        log.info("user location lat={}, lon={}", userLatitude, userLongitude);
 
-        // 진행 중인 약속이 있는지 검증
         List<AppointmentStatus> activeStatuses = List.of(AppointmentStatus.PENDING, AppointmentStatus.ACCEPTED);
         boolean hasActiveAppointment = appointmentRepository.existsByUserIdAndStatusIn(userId, activeStatuses);
 
         if (hasActiveAppointment) {
-            log.warn("이미 진행 중인 약속이 존재함 - 사용자 ID: {}", userId);
-            throw new IllegalStateException("이미 진행 중인 약속이 있습니다. 기존 약속을 완료하거나 취소해주세요.");
+            log.warn("active appointment already exists for userId={}", userId);
+            throw new IllegalStateException("An active appointment already exists. Complete or cancel it first.");
         }
 
         User user = userRepository.findById(userId)
-                .orElseThrow(() -> new RuntimeException("사용자를 찾을 수 없습니다."));
+                .orElseThrow(() -> new RuntimeException("User not found."));
 
         Appointment appointment = new Appointment();
         appointment.setUser(user);
         appointment.setStatus(AppointmentStatus.PENDING);
         appointment.setScheduledAt(scheduledAt);
+        appointment.setSearchRadius(EnvironmentContext.resolveSearchRadius(searchRadius));
+        log.info("resolved appointment search radius={}km", appointment.getSearchRadius());
 
-        // 미션 자동 배정 로직
+        EnvironmentContext environmentContext = buildRealTimeEnvironmentContext(
+                scheduledAt,
+                userLatitude,
+                userLongitude,
+                appointment.getSearchRadius(),
+                user
+        );
+
+        RecommendationPreferenceService.UserPreferenceProfile preferenceProfile =
+                recommendationPreferenceService.buildProfile(userId);
+        logPreferenceProfile("create appointment", userId, preferenceProfile);
+
         MissionTemplate selectedMission;
-        
         if (missionId != null) {
-            // 1. 미션 ID가 명시된 경우 (기존 로직 유지)
-            log.info("미션 ID가 제공됨 - 미션 및 장소 매칭 시작");
+            log.info("explicit mission supplied; validating mission and constraints");
             selectedMission = missionTemplateRepository.findById(missionId)
-                    .orElseThrow(() -> new IllegalArgumentException("미션을 찾을 수 없습니다."));
+                    .orElseThrow(() -> new IllegalArgumentException("Mission not found."));
+            validateMissionAgainstHardConstraints(selectedMission, user.getTags(), "create appointment explicit mission");
         } else {
-            // 2. 미션 ID가 없는 경우 - 자동 랜덤 배정 (핵심 로직)
-            log.info("미션 ID 없음 - 시간/날씨에 맞는 미션 자동 선정 시작");
-            
-            // 2-1. 시간대 분석
-            List<TimeOfDay> targetTimes = analyzeTimeOfDay(scheduledAt);
-            log.info("분석된 시간대: {}", targetTimes);
-            
-            // 2-2. 날씨/장소 분석 (추후 날씨 API 연동)
-            List<LocationType> targetLocations = analyzeLocation();
-            log.info("추천 장소 타입: {}", targetLocations);
-            
-            // 2-3. 조건에 맞는 미션 후보 조회
+            log.info("no explicit mission supplied; selecting mission from environment context");
+
+            List<TimeOfDay> targetTimes = resolveTimeOfDayOptions(environmentContext);
+            log.info("resolved target times={}", targetTimes);
+
+            List<LocationType> targetLocations = resolveLocationTypes(environmentContext);
+            log.info("resolved target locations={}", targetLocations);
+
             List<MissionTemplate> candidates = missionTemplateRepository
                     .findAllByTimeOfDayInAndLocationTypeIn(targetTimes, targetLocations);
+            log.info("mission candidates after time/location filter={}", candidates.size());
 
-            log.info("조건에 맞는 미션 후보: {}개", candidates.size());
-
-            // 2-3-1. 사용자 태그 기반 필터링 (태그 충돌 제외)
             String userTags = user.getTags();
             if (userTags != null && !userTags.trim().isEmpty()) {
-                log.info("🏷️ 사용자 태그 필터링 적용: {}", userTags);
+                log.info("applying user tag constraints to mission candidates: {}", userTags);
                 List<MissionTemplate> filteredCandidates = candidates.stream()
-                        .filter(mission -> !hasTagConflict(userTags, mission.getTags()))
+                        .filter(mission -> !hasSharedTagConflict(userTags, mission.getTags()))
                         .collect(Collectors.toList());
 
-                log.info("태그 필터링 후 미션 후보: {}개 (제외된 미션: {}개)",
+                log.info(
+                        "mission candidates after hard constraint filter={} (removed={})",
                         filteredCandidates.size(),
-                        candidates.size() - filteredCandidates.size());
+                        candidates.size() - filteredCandidates.size()
+                );
 
-                // 필터링 후에도 후보가 있으면 사용
-                if (!filteredCandidates.isEmpty()) {
-                    candidates = filteredCandidates;
-                } else {
-                    log.warn("⚠️ 태그 필터링 후 미션 후보가 0개 - 필터링 무시하고 진행");
+                candidates = filteredCandidates;
+                if (filteredCandidates.isEmpty()) {
+                    log.warn("create appointment mission hard constraints removed every mission candidate; no fallback will bypass user constraints");
                 }
             }
 
             if (candidates.isEmpty()) {
-                throw new IllegalStateException(
-                    "약속 시간에 맞는 미션을 찾을 수 없습니다. 관리자에게 문의해주세요."
-                );
+                throw new IllegalStateException("No mission candidate is available for the scheduled time.");
             }
 
-            // 2-4. 가중치 기반 랜덤 선정 (저장한 약속 카테고리 우선)
-            selectedMission = selectMissionWithCategoryWeight(userId, candidates);
+            selectedMission = selectMissionWithCategoryWeight(
+                    candidates,
+                    preferenceProfile,
+                    "create appointment mission weighting"
+            );
 
-            log.info("자동 선정된 미션: {} (ID: {}, 카테고리: {})",
-                    selectedMission.getTitle(), selectedMission.getId(), selectedMission.getCategory());
+            log.info(
+                    "selected mission title={}, id={}, category={}",
+                    selectedMission.getTitle(),
+                    selectedMission.getId(),
+                    selectedMission.getCategory()
+            );
         }
 
-        // 3. 선정된 미션을 Appointment에 연결
         appointment.updateMission(selectedMission);
-        log.info("미션 연결 완료 - 카테고리: {}, 장소 필수: {}", 
-                selectedMission.getCategory(), 
-                selectedMission.getIsPlaceRequired());
+        log.info(
+                "mission attached category={}, placeRequired={}",
+                selectedMission.getCategory(),
+                selectedMission.getIsPlaceRequired()
+        );
 
-        // 4. 장소 조건부 매칭 (개선된 로직: 거리 제한 포함)
         if (selectedMission.getIsPlaceRequired() != null && selectedMission.getIsPlaceRequired()) {
-            // 4-1. 장소가 필요한 미션 -> 필터링된 양질의 장소 자동 매칭 (반경 10km 이내)
-            log.info("🏠 장소가 필요한 미션 - 필터링된 장소 자동 매칭 시작 (반경 10km 이내)");
+            log.info("place-required mission - ranked nearby place matching start (radius={}km)", appointment.getSearchRadius());
 
-            Place matchedPlace = findQualityPlaceNearby(user, selectedMission.getCategory(), userLatitude, userLongitude);
+            Place matchedPlace = findRankedQualityPlaceNearby(
+                    selectedMission.getCategory(),
+                    scheduledAt,
+                    environmentContext,
+                    preferenceProfile
+            );
 
             if (matchedPlace != null) {
                 appointment.updatePlace(matchedPlace);
-                log.info("✅ 선택된 장소: {} (카테고리: {})", matchedPlace.getName(), matchedPlace.getCategory());
+                log.info("selected place name={}, category={}", matchedPlace.getName(), matchedPlace.getCategory());
             } else {
-                log.error("❌ 장소 매칭 실패! 카테고리: {} - 반경 10km 내 필터링 후 적합한 장소가 없음", selectedMission.getCategory());
+                log.error(
+                        "place matching failed: category={}, radius={}km, no viable place after filtering",
+                        selectedMission.getCategory(),
+                        appointment.getSearchRadius()
+                );
                 throw new IllegalStateException(
-                    "이 미션은 장소가 필요하지만 주변 10km 이내에서 적절한 장소를 찾을 수 없습니다. 다른 지역을 시도해주세요."
+                        String.format(
+                                "No viable place was found within %dkm for this mission.",
+                                appointment.getSearchRadius()
+                        )
                 );
             }
         } else {
-            // 4-2. 장소가 필요 없는 미션 -> 장소 없이 진행
-            log.info("🌍 장소가 필요 없는 미션 - 어디서든 수행 가능");
+            log.info("place not required for selected mission");
             appointment.setPlace(null);
         }
 
         Appointment savedAppointment = appointmentRepository.save(appointment);
-        log.info("=== 약속 생성 완료 (ID: {}) ===", savedAppointment.getId());
-        log.info("📋 미션: {} (ID: {})", selectedMission.getTitle(), selectedMission.getId());
-        log.info("📍 장소: {}", savedAppointment.getPlace() != null ? savedAppointment.getPlace().getName() : "없음 (어디서든 가능)");
-        log.info("🏷️ 상태: {}", savedAppointment.getStatus());
+        log.info("=== create appointment complete (id={}) ===", savedAppointment.getId());
+        log.info("mission={} (id={})", selectedMission.getTitle(), selectedMission.getId());
+        log.info(
+                "place={}",
+                savedAppointment.getPlace() != null ? savedAppointment.getPlace().getName() : "none"
+        );
+        log.info("status={}", savedAppointment.getStatus());
 
-        // 약속 생성 후 매직 토큰 만료 처리
         if (user.getMagicToken() != null) {
-            log.info("매직 토큰 만료 처리 - User: {} ({})", user.getNickname(), user.getEmail());
+            log.info("clearing magic token for user {} ({})", user.getNickname(), user.getEmail());
             user.setMagicToken(null);
             user.setMagicTokenExpiry(null);
             userRepository.save(user);
@@ -257,229 +246,459 @@ public class AppointmentService {
         return savedAppointment;
     }
 
-    /**
-     * 필터링된 양질의 장소 찾기 (거리 제한 포함 + 태그 필터링)
-     * @param user 사용자 객체 (태그 필터링용)
-     * @param missionCategory 미션 카테고리
-     * @param userLatitude 사용자 위도
-     * @param userLongitude 사용자 경도
-     * @return 매칭된 장소 (없으면 null)
-     */
-    private Place findQualityPlaceNearby(User user,
-                                         com.littleescape.api.domain.type.MissionCategory missionCategory,
-                                         Double userLatitude, Double userLongitude) {
-        log.info("=== 필터링된 양질의 장소 검색 시작 (반경 10km 이내) ===");
-        log.info("미션 카테고리: {}, 사용자 위치: ({}, {})", missionCategory, userLatitude, userLongitude);
+    private Place findRankedQualityPlaceNearby(com.littleescape.api.domain.type.MissionCategory missionCategory,
+                                               LocalDateTime scheduledAt,
+                                               EnvironmentContext environmentContext,
+                                               RecommendationPreferenceService.UserPreferenceProfile preferenceProfile) {
+        if (environmentContext.getLatitude() == null || environmentContext.getLongitude() == null) {
+            log.warn("nearby ranking requested without user coordinates; falling back to global ranking");
+            return findRankedQualityPlace(missionCategory, scheduledAt, environmentContext, preferenceProfile);
+        }
 
-        // 1단계: 미션 카테고리에 매칭되는 장소 카테고리 목록 가져오기
+        log.info("=== ranked quality place search start (within {}km) ===", environmentContext.getSearchRadius());
+        log.info("missionCategory={}, userLocation=({}, {}), scheduledAt={}, weather={}, airQuality={}, congestion={}, mbti={}",
+                missionCategory,
+                environmentContext.getLatitude(),
+                environmentContext.getLongitude(),
+                scheduledAt,
+                environmentContext.getWeather(),
+                environmentContext.getAirQuality(),
+                environmentContext.getCongestion(),
+                environmentContext.getUserMbti());
+
         List<com.littleescape.api.domain.type.MissionCategory> targetCategories =
-            getCategoryMapping(missionCategory);
+                resolveCategoryMapping(missionCategory);
+        int strictRadius = EnvironmentContext.resolveSearchRadius(environmentContext.getSearchRadius());
+        int relaxedRadius = relaxedSearchRadius(strictRadius);
+        List<Place> candidatePool = queryNearbyPlaceCandidates(
+                targetCategories,
+                scheduledAt,
+                environmentContext,
+                strictRadius,
+                false,
+                "strict nearby category"
+        );
 
-        log.info("매칭 시도 카테고리 목록: {}", targetCategories);
-
-        // 2단계: 각 카테고리별로 필터링된 장소 검색 (거리 제한 포함)
-        List<Place> allFilteredPlaces = new ArrayList<>();
-
-        for (com.littleescape.api.domain.type.MissionCategory targetCategory : targetCategories) {
-            List<Place> filteredPlaces = placeRepository.findByCategoryFilteredWithDistance(
-                targetCategory,
-                userLatitude, userLongitude,
-                BAD_KEYWORDS[0], BAD_KEYWORDS[1], BAD_KEYWORDS[2], BAD_KEYWORDS[3],
-                BAD_KEYWORDS[4], BAD_KEYWORDS[5], BAD_KEYWORDS[6]
+        if (candidatePool.size() < MIN_PLACE_CANDIDATE_POOL && relaxedRadius > strictRadius) {
+            int beforeCount = candidatePool.size();
+            List<Place> relaxedDistanceCandidates = queryNearbyPlaceCandidates(
+                    targetCategories,
+                    scheduledAt,
+                    environmentContext,
+                    relaxedRadius,
+                    false,
+                    "fallback relax distance"
             );
-            log.info("카테고리 {} - 반경 10km 내 필터링된 장소: {}개", targetCategory, filteredPlaces.size());
-            allFilteredPlaces.addAll(filteredPlaces);
+            candidatePool = mergeDistinctPlaces(candidatePool, relaxedDistanceCandidates);
+            log.info(
+                    "fallback RELAX_DISTANCE applied: radiusKm {} -> {}, candidates {} -> {}",
+                    strictRadius,
+                    relaxedRadius,
+                    beforeCount,
+                    candidatePool.size()
+            );
         }
 
-        log.info("총 필터링된 장소 개수 (반경 10km 이내): {}개", allFilteredPlaces.size());
-
-        // 3단계: 매칭된 장소가 없으면 Fallback (카테고리 무관, 거리+필터링만 유지)
-        if (allFilteredPlaces.isEmpty()) {
-            log.warn("카테고리 매칭된 장소 없음 - Fallback으로 전체 필터링된 장소 검색 (반경 10km 이내)");
-            allFilteredPlaces = placeRepository.findAllFilteredWithDistance(
-                userLatitude, userLongitude,
-                BAD_KEYWORDS[0], BAD_KEYWORDS[1], BAD_KEYWORDS[2], BAD_KEYWORDS[3],
-                BAD_KEYWORDS[4], BAD_KEYWORDS[5], BAD_KEYWORDS[6]
+        if (candidatePool.size() < MIN_PLACE_CANDIDATE_POOL) {
+            int beforeCount = candidatePool.size();
+            List<Place> relaxedCategoryCandidates = queryNearbyPlaceCandidates(
+                    targetCategories,
+                    scheduledAt,
+                    environmentContext,
+                    relaxedRadius,
+                    true,
+                    "fallback relax category"
             );
-            log.info("Fallback - 반경 10km 내 전체 필터링된 장소: {}개", allFilteredPlaces.size());
+            candidatePool = mergeDistinctPlaces(candidatePool, relaxedCategoryCandidates);
+            log.info(
+                    "fallback RELAX_CATEGORY applied: radiusKm={}, candidates {} -> {}",
+                    relaxedRadius,
+                    beforeCount,
+                    candidatePool.size()
+            );
         }
 
-        // 4단계: 사용자 태그 기반 장소 필터링
-        String userTags = user.getTags();
-        if (userTags != null && !userTags.trim().isEmpty()) {
-            log.info("🏷️ 사용자 태그 기반 장소 필터링 적용: {}", userTags);
-            List<Place> tagFilteredPlaces = allFilteredPlaces.stream()
-                    .filter(place -> !hasTagConflict(userTags, place.getTags()))
-                    .collect(Collectors.toList());
+        if (candidatePool.isEmpty()) {
+            log.warn(
+                    "nearby place fallback exhausted while preserving hard constraints {}",
+                    recommendationTagConflictService.normalizeHardConstraintTags(environmentContext.getUserTags())
+            );
+            return null;
+        }
 
-            log.info("태그 필터링 후 장소 후보: {}개 (제외된 장소: {}개)",
-                    tagFilteredPlaces.size(),
-                    allFilteredPlaces.size() - tagFilteredPlaces.size());
+        List<Place> diversifiedCandidates = diversifyDataSources(candidatePool, "nearby ranking");
+        return selectRankedPlace(
+                diversifiedCandidates,
+                missionCategory,
+                environmentContext,
+                preferenceProfile,
+                "nearby ranking"
+        );
+    }
 
-            // 필터링 후에도 후보가 있으면 사용
-            if (!tagFilteredPlaces.isEmpty()) {
-                allFilteredPlaces = tagFilteredPlaces;
-            } else {
-                log.warn("⚠️ 태그 필터링 후 장소 후보가 0개 - 필터링 무시하고 진행");
+    private Place findRankedQualityPlace(com.littleescape.api.domain.type.MissionCategory missionCategory,
+                                         LocalDateTime scheduledAt,
+                                         EnvironmentContext environmentContext,
+                                         RecommendationPreferenceService.UserPreferenceProfile preferenceProfile) {
+        log.info("=== ranked quality place search start (no distance input) ===");
+        log.info("missionCategory={}, scheduledAt={}, weather={}, airQuality={}, congestion={}, mbti={}",
+                missionCategory,
+                scheduledAt,
+                environmentContext.getWeather(),
+                environmentContext.getAirQuality(),
+                environmentContext.getCongestion(),
+                environmentContext.getUserMbti());
+
+        List<com.littleescape.api.domain.type.MissionCategory> targetCategories =
+                resolveCategoryMapping(missionCategory);
+        log.info("fallback RELAX_DISTANCE skipped: user location unavailable");
+
+        List<Place> candidatePool = queryGlobalPlaceCandidates(
+                targetCategories,
+                scheduledAt,
+                environmentContext,
+                false,
+                "strict global category"
+        );
+
+        if (candidatePool.size() < MIN_PLACE_CANDIDATE_POOL) {
+            int beforeCount = candidatePool.size();
+            List<Place> relaxedCategoryCandidates = queryGlobalPlaceCandidates(
+                    targetCategories,
+                    scheduledAt,
+                    environmentContext,
+                    true,
+                    "fallback global category relax"
+            );
+            candidatePool = mergeDistinctPlaces(candidatePool, relaxedCategoryCandidates);
+            log.info(
+                    "fallback RELAX_CATEGORY applied without distance input: candidates {} -> {}",
+                    beforeCount,
+                    candidatePool.size()
+            );
+        }
+
+        if (candidatePool.isEmpty()) {
+            log.warn(
+                    "global place fallback exhausted while preserving hard constraints {}",
+                    recommendationTagConflictService.normalizeHardConstraintTags(environmentContext.getUserTags())
+            );
+            return null;
+        }
+
+        List<Place> diversifiedCandidates = diversifyDataSources(candidatePool, "default ranking");
+        return selectRankedPlace(
+                diversifiedCandidates,
+                missionCategory,
+                environmentContext,
+                preferenceProfile,
+                "default ranking"
+        );
+    }
+
+    private Place selectRankedPlace(List<Place> candidates,
+                                    com.littleescape.api.domain.type.MissionCategory missionCategory,
+                                    EnvironmentContext environmentContext,
+                                    RecommendationPreferenceService.UserPreferenceProfile preferenceProfile,
+                                    String stageLabel) {
+        PlaceRecommendationScoringService.PlaceSelectionResult selectionResult =
+                placeRecommendationScoringService.selectTopPlace(
+                        candidates,
+                        new PlaceRecommendationScoringService.PlaceRankingContext(
+                                missionCategory,
+                                environmentContext != null ? environmentContext.getUserTags() : null,
+                                environmentContext != null ? environmentContext.getLatitude() : null,
+                                environmentContext != null ? environmentContext.getLongitude() : null,
+                                EnvironmentContext.resolveSearchRadius(
+                                        environmentContext != null ? environmentContext.getSearchRadius() : null
+                                ),
+                                environmentContext,
+                                preferenceProfile
+                        )
+                );
+
+        logPlaceRanking(stageLabel, selectionResult);
+        return selectionResult.selected() != null ? selectionResult.selected().place() : null;
+    }
+
+    private List<Place> queryNearbyPlaceCandidates(List<com.littleescape.api.domain.type.MissionCategory> targetCategories,
+                                                   LocalDateTime scheduledAt,
+                                                   EnvironmentContext environmentContext,
+                                                   int radiusKm,
+                                                   boolean relaxCategory,
+                                                   String stageLabel) {
+        List<Place> queriedPlaces = new ArrayList<>();
+        if (relaxCategory) {
+            queriedPlaces.addAll(placeRepository.findAllFilteredWithDistanceAndRadius(
+                    environmentContext.getLatitude(),
+                    environmentContext.getLongitude(),
+                    radiusKm,
+                    BAD_KEYWORDS[0], BAD_KEYWORDS[1], BAD_KEYWORDS[2], BAD_KEYWORDS[3],
+                    BAD_KEYWORDS[4], BAD_KEYWORDS[5], BAD_KEYWORDS[6]
+            ));
+        } else {
+            for (com.littleescape.api.domain.type.MissionCategory targetCategory : targetCategories) {
+                List<Place> filteredPlaces = placeRepository.findByCategoryFilteredWithDistanceAndRadius(
+                        targetCategory,
+                        environmentContext.getLatitude(),
+                        environmentContext.getLongitude(),
+                        radiusKm,
+                        BAD_KEYWORDS[0], BAD_KEYWORDS[1], BAD_KEYWORDS[2], BAD_KEYWORDS[3],
+                        BAD_KEYWORDS[4], BAD_KEYWORDS[5], BAD_KEYWORDS[6]
+                );
+                log.info("{} - queried category {} count={}", stageLabel, targetCategory, filteredPlaces.size());
+                queriedPlaces.addAll(filteredPlaces);
             }
         }
 
-        // 5단계: 랜덤 선택
-        if (!allFilteredPlaces.isEmpty()) {
-            Collections.shuffle(allFilteredPlaces);
-            Place selectedPlace = allFilteredPlaces.get(0);
-            log.info("=== 최종 선택된 장소: {} (카테고리: {}) ===", selectedPlace.getName(), selectedPlace.getCategory());
-            return selectedPlace;
-        }
-
-        log.error("=== 반경 10km 내 필터링 후에도 적합한 장소를 찾을 수 없음 ===");
-        return null;
+        return finalizePlaceCandidates(
+                queriedPlaces,
+                scheduledAt,
+                environmentContext.getUserTags(),
+                stageLabel
+        );
     }
 
-    /**
-     * 필터링된 양질의 장소 찾기 (거리 제한 없음 - 레거시)
-     * updateAppointmentMission에서 사용 (사용자 위치 정보가 없는 경우)
-     * @param missionCategory 미션 카테고리
-     * @return 매칭된 장소 (없으면 null)
-     */
-    private Place findQualityPlace(com.littleescape.api.domain.type.MissionCategory missionCategory) {
-        log.info("=== 필터링된 양질의 장소 검색 시작 (거리 제한 없음) ===");
-        log.info("미션 카테고리: {}", missionCategory);
-
-        // 1단계: 미션 카테고리에 매칭되는 장소 카테고리 목록 가져오기
-        List<com.littleescape.api.domain.type.MissionCategory> targetCategories =
-            getCategoryMapping(missionCategory);
-
-        log.info("매칭 시도 카테고리 목록: {}", targetCategories);
-
-        // 2단계: 각 카테고리별로 필터링된 장소 검색
-        List<Place> allFilteredPlaces = new ArrayList<>();
-
-        for (com.littleescape.api.domain.type.MissionCategory targetCategory : targetCategories) {
-            List<Place> filteredPlaces = placeRepository.findByCategoryFiltered(
-                targetCategory,
-                BAD_KEYWORDS[0], BAD_KEYWORDS[1], BAD_KEYWORDS[2], BAD_KEYWORDS[3],
-                BAD_KEYWORDS[4], BAD_KEYWORDS[5], BAD_KEYWORDS[6]
-            );
-            log.info("카테고리 {} - 필터링된 장소: {}개", targetCategory, filteredPlaces.size());
-            allFilteredPlaces.addAll(filteredPlaces);
+    private List<Place> queryGlobalPlaceCandidates(List<com.littleescape.api.domain.type.MissionCategory> targetCategories,
+                                                   LocalDateTime scheduledAt,
+                                                   EnvironmentContext environmentContext,
+                                                   boolean relaxCategory,
+                                                   String stageLabel) {
+        List<Place> queriedPlaces = new ArrayList<>();
+        if (relaxCategory) {
+            queriedPlaces.addAll(placeRepository.findAllFiltered(
+                    BAD_KEYWORDS[0], BAD_KEYWORDS[1], BAD_KEYWORDS[2], BAD_KEYWORDS[3],
+                    BAD_KEYWORDS[4], BAD_KEYWORDS[5], BAD_KEYWORDS[6]
+            ));
+        } else {
+            for (com.littleescape.api.domain.type.MissionCategory targetCategory : targetCategories) {
+                List<Place> filteredPlaces = placeRepository.findByCategoryFiltered(
+                        targetCategory,
+                        BAD_KEYWORDS[0], BAD_KEYWORDS[1], BAD_KEYWORDS[2], BAD_KEYWORDS[3],
+                        BAD_KEYWORDS[4], BAD_KEYWORDS[5], BAD_KEYWORDS[6]
+                );
+                log.info("{} - queried category {} count={}", stageLabel, targetCategory, filteredPlaces.size());
+                queriedPlaces.addAll(filteredPlaces);
+            }
         }
 
-        log.info("총 필터링된 장소 개수: {}개", allFilteredPlaces.size());
-
-        // 3단계: 매칭된 장소가 없으면 Fallback (카테고리 무관, 필터링만 유지)
-        if (allFilteredPlaces.isEmpty()) {
-            log.warn("카테고리 매칭된 장소 없음 - Fallback으로 전체 필터링된 장소 검색");
-            allFilteredPlaces = placeRepository.findAllFiltered(
-                BAD_KEYWORDS[0], BAD_KEYWORDS[1], BAD_KEYWORDS[2], BAD_KEYWORDS[3],
-                BAD_KEYWORDS[4], BAD_KEYWORDS[5], BAD_KEYWORDS[6]
-            );
-            log.info("Fallback - 전체 필터링된 장소: {}개", allFilteredPlaces.size());
-        }
-
-        // 4단계: 랜덤 선택
-        if (!allFilteredPlaces.isEmpty()) {
-            Collections.shuffle(allFilteredPlaces);
-            Place selectedPlace = allFilteredPlaces.get(0);
-            log.info("=== 최종 선택된 장소: {} (카테고리: {}) ===", selectedPlace.getName(), selectedPlace.getCategory());
-            return selectedPlace;
-        }
-
-        log.error("=== 필터링 후에도 적합한 장소를 찾을 수 없음 ===");
-        return null;
+        return finalizePlaceCandidates(
+                queriedPlaces,
+                scheduledAt,
+                environmentContext != null ? environmentContext.getUserTags() : null,
+                stageLabel
+        );
     }
 
-    /**
-     * 미션 카테고리에 따른 장소 카테고리 매핑 전략
-     * @param missionCategory 미션 카테고리
-     * @return 매칭 가능한 장소 카테고리 목록
-     */
-    private List<com.littleescape.api.domain.type.MissionCategory> getCategoryMapping(
+    private List<Place> finalizePlaceCandidates(List<Place> queriedPlaces,
+                                                LocalDateTime scheduledAt,
+                                                String userTags,
+                                                String stageLabel) {
+        List<Place> deduplicatedPlaces = mergeDistinctPlaces(List.of(), queriedPlaces);
+        List<Place> availablePlaces = filterPlacesByAvailability(deduplicatedPlaces, scheduledAt, stageLabel);
+        RecommendationTagConflictService.TagConflictFilterResult<Place> hardConstraintResult =
+                recommendationTagConflictService.filterConflicts(availablePlaces, userTags, Place::getTags);
+
+        log.info(
+                "{} - hard constraints {} kept {} of {} available places",
+                stageLabel,
+                hardConstraintResult.normalizedUserTags(),
+                hardConstraintResult.candidates().size(),
+                availablePlaces.size()
+        );
+        hardConstraintResult.steps().forEach(step -> log.info(
+                "{} - hard constraint reason={}, before={}, after={}, detail={}",
+                stageLabel,
+                step.reasonCode(),
+                step.beforeCount(),
+                step.afterCount(),
+                step.detail()
+        ));
+
+        if (!availablePlaces.isEmpty() && hardConstraintResult.candidates().isEmpty()) {
+            log.warn("{} - hard constraints removed every place candidate and will not be relaxed", stageLabel);
+        }
+
+        return hardConstraintResult.candidates();
+    }
+
+    private List<Place> mergeDistinctPlaces(List<Place> basePlaces, List<Place> additionalPlaces) {
+        Map<String, Place> distinctPlaces = new java.util.LinkedHashMap<>();
+
+        for (Place place : basePlaces) {
+            distinctPlaces.putIfAbsent(placeKey(place), place);
+        }
+        for (Place place : additionalPlaces) {
+            distinctPlaces.putIfAbsent(placeKey(place), place);
+        }
+
+        return new ArrayList<>(distinctPlaces.values());
+    }
+
+    private List<Place> diversifyDataSources(List<Place> candidates, String stageLabel) {
+        if (candidates.size() <= MIN_PLACE_CANDIDATE_POOL) {
+            return candidates;
+        }
+
+        Map<com.littleescape.api.domain.type.DataSource, List<Place>> groupedBySource = candidates.stream()
+                .collect(Collectors.groupingBy(
+                        place -> place.getDataSource() != null
+                                ? place.getDataSource()
+                                : com.littleescape.api.domain.type.DataSource.MANUAL
+                ));
+
+        if (groupedBySource.size() <= 1) {
+            log.info("{} - fallback DIVERSIFY_DATASOURCE skipped: only one data source present", stageLabel);
+            return candidates;
+        }
+
+        List<Place> diversifiedCandidates = groupedBySource.entrySet().stream()
+                .sorted(Map.Entry.comparingByKey())
+                .flatMap(entry -> entry.getValue().stream().limit(DATA_SOURCE_PER_SOURCE_CAP))
+                .collect(Collectors.toList());
+
+        if (diversifiedCandidates.size() != candidates.size()) {
+            log.info(
+                    "{} - fallback DIVERSIFY_DATASOURCE applied: candidates {} -> {}, sources={}",
+                    stageLabel,
+                    candidates.size(),
+                    diversifiedCandidates.size(),
+                    groupedBySource.keySet()
+            );
+        }
+
+        return diversifiedCandidates;
+    }
+
+    private int relaxedSearchRadius(int baseRadiusKm) {
+        return Math.min(MAX_RELAXED_RADIUS_KM, Math.max(baseRadiusKm + 5, baseRadiusKm * 2));
+    }
+
+    private String placeKey(Place place) {
+        if (place.getId() != null) {
+            return "id:" + place.getId();
+        }
+        return "name:" + String.valueOf(place.getName()) + "|address:" + String.valueOf(place.getAddress());
+    }
+
+    private void logPlaceRanking(String stageLabel,
+                                 PlaceRecommendationScoringService.PlaceSelectionResult selectionResult) {
+        if (selectionResult.rankedCandidates().isEmpty()) {
+            log.warn("{} - no place candidates available for ranking", stageLabel);
+            return;
+        }
+
+        selectionResult.rankedCandidates().stream()
+                .limit(3)
+                .forEach(candidate -> log.info(
+                        "{} - candidate placeId={}, name={}, totalScore={}, distanceKm={}, components={}",
+                        stageLabel,
+                        candidate.place().getId(),
+                        candidate.place().getName(),
+                        candidate.totalScore(),
+                        candidate.distanceKm(),
+                        candidate.components()
+                ));
+
+        PlaceRecommendationScoringService.PlaceScore selected = selectionResult.selected();
+        log.info(
+                "{} - selected placeId={}, name={}, totalScore={}, tieCandidates={}, tieBreakApplied={}, components={}",
+                stageLabel,
+                selected.place().getId(),
+                selected.place().getName(),
+                selected.totalScore(),
+                selectionResult.tieCandidateCount(),
+                selectionResult.tieBreakApplied(),
+                selected.components()
+        );
+    }
+
+    private EnvironmentContext buildRealTimeEnvironmentContext(LocalDateTime targetDateTime,
+                                                               Double latitude,
+                                                               Double longitude,
+                                                               Integer searchRadius,
+                                                               User user) {
+        RecommendationEnvironmentService.RealTimeEnvironmentSnapshot snapshot =
+                recommendationEnvironmentService.resolveSnapshot(latitude, longitude);
+
+        EnvironmentContext context = EnvironmentContext.fromRealTime(
+                targetDateTime,
+                latitude,
+                longitude,
+                searchRadius,
+                snapshot.weather(),
+                snapshot.temperature(),
+                snapshot.airQuality(),
+                snapshot.congestion(),
+                user != null ? user.getMbti() : null,
+                user != null ? user.getTags() : null
+        );
+
+        log.info(
+                "real-time environment resolved: source={}, searchRadius={}km, weather={}, temperature={}, airQuality={}, congestion={}, indoorPreferred={}, outdoorRestricted={}, quietPreferred={}, mbti={}",
+                snapshot.source(),
+                context.getSearchRadius(),
+                context.getWeather(),
+                context.getTemperature(),
+                context.getAirQuality(),
+                context.getCongestion(),
+                context.isIndoorPreferred(),
+                context.isOutdoorRestricted(),
+                context.prefersQuietPlace(),
+                context.getUserMbti()
+        );
+        return context;
+    }
+
+    private List<TimeOfDay> resolveTimeOfDayOptions(EnvironmentContext environmentContext) {
+        return recommendationSupportService.resolveTimeOfDayOptions(environmentContext);
+    }
+
+    private List<LocationType> resolveLocationTypes(EnvironmentContext environmentContext) {
+        return recommendationSupportService.resolveLocationTypes(environmentContext);
+    }
+
+    private boolean hasSharedTagConflict(String userTags, String targetTags) {
+        return recommendationTagConflictService.hasConflict(userTags, targetTags);
+    }
+
+    private List<com.littleescape.api.domain.type.MissionCategory> resolveCategoryMapping(
         com.littleescape.api.domain.type.MissionCategory missionCategory) {
-
-        List<com.littleescape.api.domain.type.MissionCategory> mapping = new ArrayList<>();
-
-        switch (missionCategory) {
-            case ACTIVITY:
-                // 활동(산책, 운동 등) -> ACTIVITY 우선, 부가적으로 CULTURE
-                mapping.add(com.littleescape.api.domain.type.MissionCategory.ACTIVITY);
-                mapping.add(com.littleescape.api.domain.type.MissionCategory.CULTURE);
-                break;
-
-            case CULTURE:
-                // 문화(전시/관람) -> CULTURE만
-                mapping.add(com.littleescape.api.domain.type.MissionCategory.CULTURE);
-                break;
-
-            case RELAX:
-                // 휴식(카페, 도서관) -> RELAX 우선, 부가적으로 CULTURE
-                mapping.add(com.littleescape.api.domain.type.MissionCategory.RELAX);
-                mapping.add(com.littleescape.api.domain.type.MissionCategory.CULTURE);
-                break;
-
-            case FOOD:
-                // 음식 -> FOOD 우선, 부가적으로 RELAX
-                mapping.add(com.littleescape.api.domain.type.MissionCategory.FOOD);
-                mapping.add(com.littleescape.api.domain.type.MissionCategory.RELAX);
-                break;
-
-            default:
-                // 기본값: 미션 카테고리 그대로
-                mapping.add(missionCategory);
-                break;
-        }
-
-        return mapping;
+        return recommendationSupportService.mapMissionToPlaceCategories(missionCategory);
     }
 
-    /**
-     * 시간대 분석 로직
-     * @param scheduledAt 약속 예정 시간
-     * @return 해당 시간대 + ANY를 포함한 리스트
-     */
-    private List<TimeOfDay> analyzeTimeOfDay(LocalDateTime scheduledAt) {
-        int hour = scheduledAt.getHour();
-        List<TimeOfDay> times = new ArrayList<>();
+    private List<Place> filterPlacesByAvailability(List<Place> places,
+                                                   LocalDateTime scheduledAt,
+                                                   String stageLabel) {
+        PlaceScheduleFilterService.PlaceScheduleFilterResult scheduleResult =
+                placeScheduleFilterService.filterPlacesBySchedule(places, scheduledAt, LocalDate.now());
 
-        // 시간대별 분류
-        if (hour >= 6 && hour < 12) {
-            times.add(TimeOfDay.MORNING);
-        } else if (hour >= 12 && hour < 18) {
-            times.add(TimeOfDay.AFTERNOON);
-        } else {
-            // 18~24시 또는 0~6시는 NIGHT
-            times.add(TimeOfDay.NIGHT);
+        if (scheduleResult.beforeCount() != scheduleResult.afterCount()
+                || scheduleResult.unknownOperationalInfoCount() > 0) {
+            log.info("{} - schedule filter: {} -> {} (deactivated={}, expired={}, notStarted={}, closedDay={}, outsideHours={}, unavailableStatus={}, unknownOperationalInfo={})",
+                    stageLabel,
+                    scheduleResult.beforeCount(),
+                    scheduleResult.afterCount(),
+                    scheduleResult.deactivatedCount(),
+                    scheduleResult.expiredCount(),
+                    scheduleResult.notStartedCount(),
+                    scheduleResult.closedDayCount(),
+                    scheduleResult.outsideOperatingHoursCount(),
+                    scheduleResult.unavailableOperationInfoCount(),
+                    scheduleResult.unknownOperationalInfoCount());
+            scheduleResult.exclusionDetails().stream()
+                    .limit(3)
+                    .forEach(detail -> log.info(
+                            "{} - schedule exclusion: placeId={}, placeName={}, reason={}, detail={}",
+                            stageLabel,
+                            detail.placeId(),
+                            detail.placeName(),
+                            detail.reasonCode(),
+                            detail.detail()
+                    ));
         }
 
-        // ANY(무관)는 항상 포함
-        times.add(TimeOfDay.ANY);
-
-        return times;
-    }
-
-    /**
-     * 날씨/장소 분석 로직
-     * TODO: 날씨 API 연동 후 실제 날씨 데이터 활용
-     * @return 추천 가능한 장소 타입 리스트
-     */
-    private List<LocationType> analyzeLocation() {
-        // 임시: 날씨 API 연동 전이므로 항상 맑음으로 가정
-        boolean isRaining = false;
-
-        List<LocationType> locations = new ArrayList<>();
-
-        if (isRaining) {
-            // 비/눈: 실내와 무관만 포함
-            locations.add(LocationType.INDOOR);
-            locations.add(LocationType.ANY);
-        } else {
-            // 맑음: 모든 장소 포함
-            locations.add(LocationType.INDOOR);
-            locations.add(LocationType.OUTDOOR);
-            locations.add(LocationType.ANY);
-        }
-
-        return locations;
+        return scheduleResult.filteredPlaces();
     }
 
     @Transactional
@@ -500,12 +719,28 @@ public class AppointmentService {
         log.info("미션 카테고리: {}", missionTemplate.getCategory());
 
         // 미션 설정
+        validateMissionAgainstHardConstraints(missionTemplate, appointment.getUser().getTags(), "update appointment mission");
         appointment.updateMission(missionTemplate);
 
         // 필터링된 양질의 장소 매칭 로직
         log.info("카테고리 {}에 해당하는 필터링된 장소 조회 중...", missionTemplate.getCategory());
 
-        Place matchedPlace = findQualityPlace(missionTemplate.getCategory());
+        EnvironmentContext environmentContext = buildRealTimeEnvironmentContext(
+                appointment.getScheduledAt(),
+                null,
+                null,
+                appointment.getSearchRadius(),
+                appointment.getUser()
+        );
+        RecommendationPreferenceService.UserPreferenceProfile preferenceProfile =
+                recommendationPreferenceService.buildProfile(userId);
+        logPreferenceProfile("update appointment mission", userId, preferenceProfile);
+        Place matchedPlace = findRankedQualityPlace(
+                missionTemplate.getCategory(),
+                appointment.getScheduledAt(),
+                environmentContext,
+                preferenceProfile
+        );
 
         if (matchedPlace != null) {
             appointment.updatePlace(matchedPlace);
@@ -774,6 +1009,7 @@ public class AppointmentService {
         Appointment newAppointment = new Appointment();
         newAppointment.setUser(user);
         newAppointment.setStatus(AppointmentStatus.PENDING);
+        newAppointment.setSearchRadius(EnvironmentContext.resolveSearchRadius(oldAppointment.getSearchRadius()));
 
         // 기존 약속의 미션, 장소, 시간 정보 복사
         if (oldAppointment.getMissionTemplate() != null) {
@@ -997,6 +1233,17 @@ public class AppointmentService {
                 .orElseThrow(() -> new RuntimeException("사용자를 찾을 수 없습니다."));
 
         // 2. 기존 미션 ID 저장 (중복 방지용)
+        EnvironmentContext environmentContext = buildRealTimeEnvironmentContext(
+                appointment.getScheduledAt(),
+                null,
+                null,
+                appointment.getSearchRadius(),
+                user
+        );
+
+        RecommendationPreferenceService.UserPreferenceProfile preferenceProfile =
+                recommendationPreferenceService.buildProfile(userId);
+        logPreferenceProfile("swap mission", userId, preferenceProfile);
         Long previousMissionId = appointment.getMissionTemplate() != null
                 ? appointment.getMissionTemplate().getId()
                 : null;
@@ -1004,8 +1251,8 @@ public class AppointmentService {
         log.info("기존 미션 ID: {}", previousMissionId);
 
         // 3. 시간/날씨 조건 분석
-        List<TimeOfDay> targetTimes = analyzeTimeOfDay(appointment.getScheduledAt());
-        List<LocationType> targetLocations = analyzeLocation();
+        List<TimeOfDay> targetTimes = resolveTimeOfDayOptions(environmentContext);
+        List<LocationType> targetLocations = resolveLocationTypes(environmentContext);
 
         log.info("분석된 시간대: {}, 장소 타입: {}", targetTimes, targetLocations);
 
@@ -1028,15 +1275,13 @@ public class AppointmentService {
         if (userTags != null && !userTags.trim().isEmpty()) {
             log.info("🏷️ 사용자 태그 필터링 적용: {}", userTags);
             List<MissionTemplate> filteredCandidates = candidates.stream()
-                    .filter(mission -> !hasTagConflict(userTags, mission.getTags()))
+                    .filter(mission -> !hasSharedTagConflict(userTags, mission.getTags()))
                     .collect(Collectors.toList());
 
             log.info("태그 필터링 후 미션 후보: {}개", filteredCandidates.size());
-
-            if (!filteredCandidates.isEmpty()) {
-                candidates = filteredCandidates;
-            } else {
-                log.warn("⚠️ 태그 필터링 후 미션 후보가 0개 - 필터링 무시");
+            candidates = filteredCandidates;
+            if (filteredCandidates.isEmpty()) {
+                log.warn("swap mission hard constraints removed every mission candidate; no fallback will bypass user constraints");
             }
         }
 
@@ -1046,8 +1291,11 @@ public class AppointmentService {
         }
 
         // 8. 랜덤으로 새 미션 선택
-        Collections.shuffle(candidates);
-        MissionTemplate newMission = candidates.get(0);
+        MissionTemplate newMission = selectMissionWithCategoryWeight(
+                candidates,
+                preferenceProfile,
+                "swap mission weighting"
+        );
 
         log.info("새로 선택된 미션: {} (ID: {})", newMission.getTitle(), newMission.getId());
 
@@ -1061,7 +1309,12 @@ public class AppointmentService {
             // 사용자의 최근 위치 정보 가져오기 (위치 정보가 있다면)
             // TODO: User 엔티티에 lastLatitude, lastLongitude 필드 추가 필요
             // 현재는 Place만 교체하고 위치는 기존 정보 활용
-            Place newPlace = findQualityPlace(newMission.getCategory());
+            Place newPlace = findRankedQualityPlace(
+                    newMission.getCategory(),
+                    appointment.getScheduledAt(),
+                    environmentContext,
+                    preferenceProfile
+            );
 
             if (newPlace != null) {
                 appointment.updatePlace(newPlace);
@@ -1334,41 +1587,46 @@ public class AppointmentService {
      * @param userId 사용자 ID
      * @return 카테고리별 가중치 맵 (예: {FOOD: 2.0, ACTIVITY: 1.5, ...})
      */
-    @Transactional(readOnly = true)
-    public java.util.Map<com.littleescape.api.domain.type.MissionCategory, Double> getCategoryWeights(Long userId) {
-        List<Object[]> categoryStats = savedAppointmentRepository.findCategoryStatsByUserId(userId);
-
-        // 기본 가중치 (모든 카테고리 1.0)
-        java.util.Map<com.littleescape.api.domain.type.MissionCategory, Double> weights = new java.util.HashMap<>();
-        for (com.littleescape.api.domain.type.MissionCategory category : com.littleescape.api.domain.type.MissionCategory.values()) {
-            weights.put(category, 1.0);
+    private void logPreferenceProfile(String stageLabel,
+                                      Long userId,
+                                      RecommendationPreferenceService.UserPreferenceProfile preferenceProfile) {
+        if (preferenceProfile == null || !preferenceProfile.hasSignals()) {
+            log.info("{} - no historical personalization signals for userId={}", stageLabel, userId);
+            return;
         }
 
-        if (categoryStats.isEmpty()) {
-            log.info("저장한 약속이 없어 기본 가중치 반환");
-            return weights;
+        preferenceProfile.signals().stream()
+                .limit(8)
+                .forEach(signal -> log.info(
+                        "{} - preference signal target={}, type={}, key={}, count={}, total={}, delta={}",
+                        stageLabel,
+                        signal.targetType(),
+                        signal.signalType(),
+                        signal.key(),
+                        signal.count(),
+                        signal.totalCount(),
+                        signal.delta()
+                ));
+    }
+
+    private void validateMissionAgainstHardConstraints(MissionTemplate missionTemplate,
+                                                       String userTags,
+                                                       String stageLabel) {
+        RecommendationTagConflictService.TagConflictFilterResult<MissionTemplate> result =
+                recommendationTagConflictService.filterConflicts(
+                        List.of(missionTemplate),
+                        userTags,
+                        MissionTemplate::getTags
+                );
+
+        if (result.candidates().isEmpty() && !result.normalizedUserTags().isEmpty()) {
+            RecommendationTagConflictService.TagConflictStep step = result.steps().isEmpty()
+                    ? null
+                    : result.steps().get(result.steps().size() - 1);
+            String reasonCode = step != null ? step.reasonCode() : "USER_TAG_CONFLICT";
+            throw new IllegalArgumentException(
+                    "Mission conflicts with hard user constraints: " + reasonCode + " at " + stageLabel
+            );
         }
-
-        // 총 저장 횟수 계산
-        long totalCount = categoryStats.stream()
-                .mapToLong(row -> (Long) row[1])
-                .sum();
-
-        // 카테고리별 가중치 계산 (비율 기반)
-        for (Object[] row : categoryStats) {
-            com.littleescape.api.domain.type.MissionCategory category =
-                    (com.littleescape.api.domain.type.MissionCategory) row[0];
-            Long count = (Long) row[1];
-
-            // 가중치 = 1.0 + (해당 카테고리 비율)
-            // 예: FOOD를 60% 저장했다면 가중치 1.6
-            double weight = 1.0 + ((double) count / totalCount);
-            weights.put(category, weight);
-
-            log.info("카테고리 가중치 계산 - {}: {}회 저장 ({}%), 가중치: {}",
-                    category, count, String.format("%.1f", (double) count / totalCount * 100), weight);
-        }
-
-        return weights;
     }
 }

--- a/backend/src/main/java/com/littleescape/api/service/DataCollectionService.java
+++ b/backend/src/main/java/com/littleescape/api/service/DataCollectionService.java
@@ -550,14 +550,31 @@ public class DataCollectionService {
 
             MissionCategory category = determineCategoryFromCodeName(event.getCodeName());
             Boolean isFree = event.getIsFree() != null && "무료".equals(event.getIsFree());
+            LocalDate startDate = parseDate(event.getStartDate());
+            LocalDate endDate = parseDate(event.getEndDate());
+            String performanceState = resolvePerformanceState(null, startDate, endDate);
+            String eventUrl = event.getOrgLink() != null ? event.getOrgLink() : event.getHomepageAddr();
 
             if (existing.isPresent()) {
-                result.skipped++;  // 서울시 이벤트는 업데이트 로직 단순화
+                Place place = existing.get();
+                place.updateBasicInfo(
+                        event.getTitle(),
+                        event.getPlace(),
+                        eventUrl,
+                        latitude,
+                        longitude,
+                        category,
+                        event.getMainImg(),
+                        isFree,
+                        DataSource.SEOUL_CULTURE
+                );
+                syncPerformancePeriod(place, startDate, endDate, null, performanceState, event.getMainImg());
+                result.updated++;
             } else {
                 Place place = Place.builder()
                         .name(event.getTitle())
                         .address(event.getPlace())
-                        .url(event.getOrgLink() != null ? event.getOrgLink() : event.getHomepageAddr())
+                        .url(eventUrl)
                         .latitude(latitude)
                         .longitude(longitude)
                         .category(category)
@@ -565,7 +582,18 @@ public class DataCollectionService {
                         .dataSource(DataSource.SEOUL_CULTURE)
                         .externalId(externalId)
                         .isFree(isFree)
+                        .startDate(startDate)
+                        .endDate(endDate)
+                        .performanceState(performanceState)
+                        .isActive(endDate == null || !endDate.isBefore(LocalDate.now()))
                         .build();
+
+                place.setPerformanceDetail(PlaceDetailPerformance.builder()
+                        .startDate(startDate)
+                        .endDate(endDate)
+                        .ticketPrice(null)
+                        .performanceState(performanceState)
+                        .build());
 
                 placeRepository.save(place);
                 result.inserted++;
@@ -751,11 +779,6 @@ public class DataCollectionService {
             String externalId = event.getServiceId();
             Optional<Place> existing = placeRepository.findByExternalId(externalId);
 
-            if (existing.isPresent()) {
-                result.skipped++;
-                return;
-            }
-
             Double latitude = parseDouble(event.getLatitude());
             Double longitude = parseDouble(event.getLongitude());
 
@@ -767,10 +790,32 @@ public class DataCollectionService {
 
             Boolean isFree = "무료".equals(event.getPayType());
             MissionCategory category = determineCategoryFromClassName(event.getMaxClassName());
+            LocalDate startDate = parseDate(event.getOpenBeginDate());
+            LocalDate endDate = parseDate(event.getOpenEndDate());
+            String performanceState = resolvePerformanceState(event.getServiceStatusName(), startDate, endDate);
+            String address = event.getPlaceName() + " (" + event.getAreaName() + ")";
+
+            if (existing.isPresent()) {
+                Place place = existing.get();
+                place.updateBasicInfo(
+                        event.getServiceName(),
+                        address,
+                        event.getServiceUrl(),
+                        latitude,
+                        longitude,
+                        category,
+                        event.getImageUrl(),
+                        isFree,
+                        DataSource.SEOUL_RESERVATION
+                );
+                syncPerformancePeriod(place, startDate, endDate, null, performanceState, event.getImageUrl());
+                result.updated++;
+                return;
+            }
 
             Place place = Place.builder()
                     .name(event.getServiceName())
-                    .address(event.getPlaceName() + " (" + event.getAreaName() + ")")
+                    .address(address)
                     .url(event.getServiceUrl())
                     .latitude(latitude)
                     .longitude(longitude)
@@ -779,7 +824,18 @@ public class DataCollectionService {
                     .dataSource(DataSource.SEOUL_RESERVATION)
                     .externalId(externalId)
                     .isFree(isFree)
+                    .startDate(startDate)
+                    .endDate(endDate)
+                    .performanceState(performanceState)
+                    .isActive(endDate == null || !endDate.isBefore(LocalDate.now()))
                     .build();
+
+            place.setPerformanceDetail(PlaceDetailPerformance.builder()
+                    .startDate(startDate)
+                    .endDate(endDate)
+                    .ticketPrice(null)
+                    .performanceState(performanceState)
+                    .build());
 
             placeRepository.save(place);
             result.inserted++;
@@ -1310,6 +1366,41 @@ public class DataCollectionService {
             return MissionCategory.ACTIVITY;
         }
         return MissionCategory.CULTURE;
+    }
+
+    private void syncPerformancePeriod(Place place, LocalDate startDate, LocalDate endDate,
+                                       Integer ticketPrice, String performanceState, String imageUrl) {
+        place.updatePerformanceInfo(performanceState, ticketPrice, startDate, endDate, imageUrl);
+
+        if (place.getPerformanceDetail() == null) {
+            place.setPerformanceDetail(PlaceDetailPerformance.builder()
+                    .startDate(startDate)
+                    .endDate(endDate)
+                    .ticketPrice(ticketPrice)
+                    .performanceState(performanceState)
+                    .build());
+        }
+
+        if (endDate != null && endDate.isBefore(LocalDate.now())) {
+            place.deactivate();
+        } else {
+            place.activate();
+        }
+    }
+
+    private String resolvePerformanceState(String sourceState, LocalDate startDate, LocalDate endDate) {
+        if (sourceState != null && !sourceState.isBlank()) {
+            return sourceState;
+        }
+
+        LocalDate today = LocalDate.now();
+        if (endDate != null && endDate.isBefore(today)) {
+            return "공연완료";
+        }
+        if (startDate != null && startDate.isAfter(today)) {
+            return "공연예정";
+        }
+        return "진행중";
     }
 
     /**

--- a/backend/src/main/java/com/littleescape/api/service/MissionRecommendationSelectionService.java
+++ b/backend/src/main/java/com/littleescape/api/service/MissionRecommendationSelectionService.java
@@ -1,0 +1,118 @@
+package com.littleescape.api.service;
+
+import com.littleescape.api.domain.MissionTemplate;
+import com.littleescape.api.domain.type.MissionCategory;
+import org.springframework.stereotype.Service;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.function.DoubleSupplier;
+
+@Service
+public class MissionRecommendationSelectionService {
+
+    private static final double DEFAULT_CATEGORY_WEIGHT = 1.0;
+    private static final double MAX_RANDOM_FRACTION = Math.nextDown(1.0);
+
+    private final DoubleSupplier randomSupplier;
+
+    public MissionRecommendationSelectionService() {
+        this(() -> ThreadLocalRandom.current().nextDouble());
+    }
+
+    MissionRecommendationSelectionService(DoubleSupplier randomSupplier) {
+        this.randomSupplier = randomSupplier;
+    }
+
+    public MissionSelectionResult selectMission(
+            List<MissionTemplate> candidates,
+            RecommendationPreferenceService.UserPreferenceProfile preferenceProfile
+    ) {
+        if (candidates == null || candidates.isEmpty()) {
+            throw new IllegalArgumentException("Mission candidates must not be empty.");
+        }
+
+        List<MissionCandidateScore> rankedCandidates = candidates.stream()
+                .map(mission -> new MissionCandidateScore(
+                        mission,
+                        resolveCategoryWeight(preferenceProfile, mission.getCategory())
+                ))
+                .sorted(Comparator
+                        .comparingDouble(MissionCandidateScore::categoryWeight).reversed()
+                        .thenComparing(candidate -> candidate.mission().getTitle(), Comparator.nullsLast(String::compareTo)))
+                .toList();
+
+        if (rankedCandidates.size() == 1) {
+            MissionCandidateScore selected = rankedCandidates.get(0);
+            return new MissionSelectionResult(
+                    rankedCandidates,
+                    selected,
+                    selected.categoryWeight(),
+                    0.0,
+                    0.0
+            );
+        }
+
+        double totalWeight = rankedCandidates.stream()
+                .mapToDouble(MissionCandidateScore::categoryWeight)
+                .sum();
+        double randomFraction = normalizeRandomFraction(randomSupplier.getAsDouble());
+        double selectedPoint = totalWeight * randomFraction;
+        double cumulativeWeight = 0.0;
+
+        for (MissionCandidateScore candidate : rankedCandidates) {
+            cumulativeWeight += candidate.categoryWeight();
+            if (selectedPoint <= cumulativeWeight) {
+                return new MissionSelectionResult(
+                        rankedCandidates,
+                        candidate,
+                        totalWeight,
+                        selectedPoint,
+                        randomFraction
+                );
+            }
+        }
+
+        MissionCandidateScore fallback = rankedCandidates.get(rankedCandidates.size() - 1);
+        return new MissionSelectionResult(
+                rankedCandidates,
+                fallback,
+                totalWeight,
+                selectedPoint,
+                randomFraction
+        );
+    }
+
+    private double resolveCategoryWeight(
+            RecommendationPreferenceService.UserPreferenceProfile preferenceProfile,
+            MissionCategory category
+    ) {
+        if (preferenceProfile == null) {
+            return DEFAULT_CATEGORY_WEIGHT;
+        }
+        return preferenceProfile.categoryWeight(category);
+    }
+
+    private double normalizeRandomFraction(double value) {
+        if (Double.isNaN(value) || Double.isInfinite(value)) {
+            return 0.0;
+        }
+        return Math.max(0.0, Math.min(MAX_RANDOM_FRACTION, value));
+    }
+
+    public record MissionCandidateScore(
+            MissionTemplate mission,
+            double categoryWeight
+    ) {
+    }
+
+    public record MissionSelectionResult(
+            List<MissionCandidateScore> rankedCandidates,
+            MissionCandidateScore selected,
+            double totalWeight,
+            double selectedPoint,
+            double randomFraction
+    ) {
+    }
+}

--- a/backend/src/main/java/com/littleescape/api/service/PlaceRecommendationScoringService.java
+++ b/backend/src/main/java/com/littleescape/api/service/PlaceRecommendationScoringService.java
@@ -1,0 +1,421 @@
+package com.littleescape.api.service;
+
+import com.littleescape.api.domain.Place;
+import com.littleescape.api.domain.PlaceDetailPerformance;
+import com.littleescape.api.domain.type.DataSource;
+import com.littleescape.api.domain.type.MissionCategory;
+import com.littleescape.api.service.simulation.EnvironmentContext;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+import java.util.concurrent.ThreadLocalRandom;
+
+@Service
+@RequiredArgsConstructor
+public class PlaceRecommendationScoringService {
+
+    private static final int DEFAULT_DISTANCE_RADIUS_KM = 10;
+    private static final double DISTANCE_WEIGHT = 40.0;
+    private static final double CATEGORY_FIT_WEIGHT = 25.0;
+    private static final double PRICE_ACCESSIBILITY_WEIGHT = 15.0;
+    private static final double QUIET_PREFERENCE_WEIGHT = 10.0;
+    private static final double DATA_SOURCE_WEIGHT = 10.0;
+    private static final double SCORE_TIE_EPSILON = 0.001;
+    private static final Set<String> QUIET_PREFERENCE_TAGS = Set.of(
+            "PREFER_QUIET",
+            "QUIET_PREFERRED",
+            "QUIET"
+    );
+
+    private final RecommendationSupportService recommendationSupportService;
+    private final RecommendationTagConflictService recommendationTagConflictService;
+
+    public List<PlaceScore> rankPlaces(List<Place> places, PlaceRankingContext context) {
+        if (places == null || places.isEmpty()) {
+            return List.of();
+        }
+
+        return deduplicatePlaces(places).stream()
+                .map(place -> scorePlace(place, context))
+                .sorted(Comparator
+                        .comparingDouble(PlaceScore::totalScore).reversed()
+                        .thenComparing(score -> score.place().getName(), Comparator.nullsLast(String::compareTo))
+                        .thenComparing(score -> score.place().getAddress(), Comparator.nullsLast(String::compareTo)))
+                .toList();
+    }
+
+    public PlaceSelectionResult selectTopPlace(List<Place> places, PlaceRankingContext context) {
+        List<PlaceScore> ranked = rankPlaces(places, context);
+        if (ranked.isEmpty()) {
+            return new PlaceSelectionResult(null, ranked, 0, false);
+        }
+
+        double topScore = ranked.get(0).totalScore();
+        List<PlaceScore> topCandidates = ranked.stream()
+                .filter(candidate -> Math.abs(candidate.totalScore() - topScore) < SCORE_TIE_EPSILON)
+                .toList();
+
+        boolean tieBreakApplied = topCandidates.size() > 1;
+        PlaceScore selected = topCandidates.get(
+                tieBreakApplied ? ThreadLocalRandom.current().nextInt(topCandidates.size()) : 0
+        );
+
+        return new PlaceSelectionResult(selected, ranked, topCandidates.size(), tieBreakApplied);
+    }
+
+    private List<Place> deduplicatePlaces(List<Place> places) {
+        LinkedHashMap<String, Place> deduped = new LinkedHashMap<>();
+        for (int index = 0; index < places.size(); index++) {
+            Place place = places.get(index);
+            String key = place.getId() != null
+                    ? "id:" + place.getId()
+                    : "idx:" + index + ":" + String.valueOf(place.getName()) + ":" + String.valueOf(place.getAddress());
+            deduped.putIfAbsent(key, place);
+        }
+        return new ArrayList<>(deduped.values());
+    }
+
+    private PlaceScore scorePlace(Place place, PlaceRankingContext context) {
+        List<ScoreComponent> components = new ArrayList<>();
+
+        ScoreComponent distance = buildDistanceComponent(place, context);
+        ScoreComponent categoryFit = buildCategoryFitComponent(
+                place,
+                context.missionCategory(),
+                context.preferenceProfile()
+        );
+        ScoreComponent priceAccessibility = buildPriceAccessibilityComponent(place);
+        ScoreComponent quietPreference = buildQuietPreferenceComponent(place, context);
+        ScoreComponent dataSource = buildDataSourceComponent(place, context);
+
+        components.add(distance);
+        components.add(categoryFit);
+        components.add(priceAccessibility);
+        components.add(quietPreference);
+        components.add(dataSource);
+
+        double totalScore = roundScore(components.stream().mapToDouble(ScoreComponent::score).sum());
+        return new PlaceScore(
+                place,
+                totalScore,
+                extractDistanceKm(place, context.userLatitude(), context.userLongitude()),
+                List.copyOf(components)
+        );
+    }
+
+    private ScoreComponent buildDistanceComponent(Place place, PlaceRankingContext context) {
+        Double distanceKm = extractDistanceKm(place, context.userLatitude(), context.userLongitude());
+        if (distanceKm == null) {
+            return component(
+                    "DISTANCE",
+                    DISTANCE_WEIGHT,
+                    roundScore(DISTANCE_WEIGHT * 0.5),
+                    "user location unavailable, applied neutral distance score"
+            );
+        }
+
+        int radiusKm = context.distanceRadiusKm() != null && context.distanceRadiusKm() > 0
+                ? context.distanceRadiusKm()
+                : DEFAULT_DISTANCE_RADIUS_KM;
+        double normalized = Math.max(0.0, 1.0 - (Math.min(distanceKm, radiusKm) / radiusKm));
+        double score = DISTANCE_WEIGHT * normalized;
+
+        return component(
+                "DISTANCE",
+                DISTANCE_WEIGHT,
+                roundScore(score),
+                String.format(Locale.ROOT, "distanceKm=%.2f,radiusKm=%d", distanceKm, radiusKm)
+        );
+    }
+
+    private ScoreComponent buildCategoryFitComponent(Place place,
+                                                     MissionCategory missionCategory,
+                                                     RecommendationPreferenceService.UserPreferenceProfile preferenceProfile) {
+        List<MissionCategory> mappedCategories = recommendationSupportService.mapMissionToPlaceCategories(missionCategory);
+        MissionCategory placeCategory = place.getCategory();
+        double preferenceWeight = preferenceProfile != null
+                ? preferenceProfile.categoryWeight(placeCategory)
+                : 1.0;
+
+        if (placeCategory == missionCategory) {
+            return component(
+                    "MISSION_CATEGORY_FIT",
+                    CATEGORY_FIT_WEIGHT,
+                    applyPreferenceWeight(CATEGORY_FIT_WEIGHT, CATEGORY_FIT_WEIGHT, preferenceWeight),
+                    "direct category match,preferenceWeight=" + preferenceWeight
+            );
+        }
+
+        int mappedIndex = mappedCategories.indexOf(placeCategory);
+        if (mappedIndex >= 0) {
+            double score = mappedIndex == 1 ? 18.0 : Math.max(10.0, 18.0 - ((mappedIndex - 1) * 4.0));
+            return component(
+                    "MISSION_CATEGORY_FIT",
+                    CATEGORY_FIT_WEIGHT,
+                    applyPreferenceWeight(CATEGORY_FIT_WEIGHT, score, preferenceWeight),
+                    "mapped category match index=" + mappedIndex
+                            + ",mappedCategories=" + mappedCategories
+                            + ",preferenceWeight=" + preferenceWeight
+            );
+        }
+
+        return component(
+                "MISSION_CATEGORY_FIT",
+                CATEGORY_FIT_WEIGHT,
+                applyPreferenceWeight(CATEGORY_FIT_WEIGHT, 6.0, preferenceWeight),
+                "fallback category outside mapped categories "
+                        + mappedCategories
+                        + ",preferenceWeight=" + preferenceWeight
+        );
+    }
+
+    private ScoreComponent buildPriceAccessibilityComponent(Place place) {
+        Integer ticketPrice = resolveTicketPrice(place);
+
+        if (Boolean.TRUE.equals(place.getIsFree()) || (ticketPrice != null && ticketPrice <= 0)) {
+            return component(
+                    "PRICE_ACCESSIBILITY",
+                    PRICE_ACCESSIBILITY_WEIGHT,
+                    PRICE_ACCESSIBILITY_WEIGHT,
+                    "free entry"
+            );
+        }
+
+        if (ticketPrice == null) {
+            double score = isTypicallyFreeSource(place.getDataSource()) ? 12.0 : 9.0;
+            return component(
+                    "PRICE_ACCESSIBILITY",
+                    PRICE_ACCESSIBILITY_WEIGHT,
+                    score,
+                    "ticket price unavailable"
+            );
+        }
+
+        if (ticketPrice <= 10000) {
+            return component(
+                    "PRICE_ACCESSIBILITY",
+                    PRICE_ACCESSIBILITY_WEIGHT,
+                    12.0,
+                    "ticketPrice=" + ticketPrice
+            );
+        }
+
+        if (ticketPrice <= 20000) {
+            return component(
+                    "PRICE_ACCESSIBILITY",
+                    PRICE_ACCESSIBILITY_WEIGHT,
+                    9.0,
+                    "ticketPrice=" + ticketPrice
+            );
+        }
+
+        if (ticketPrice <= 30000) {
+            return component(
+                    "PRICE_ACCESSIBILITY",
+                    PRICE_ACCESSIBILITY_WEIGHT,
+                    5.0,
+                    "ticketPrice=" + ticketPrice
+            );
+        }
+
+        return component(
+                "PRICE_ACCESSIBILITY",
+                PRICE_ACCESSIBILITY_WEIGHT,
+                2.0,
+                "ticketPrice=" + ticketPrice
+        );
+    }
+
+    private ScoreComponent buildQuietPreferenceComponent(Place place, PlaceRankingContext context) {
+        EnvironmentContext environmentContext = context.environmentContext();
+        List<String> normalizedUserTags = recommendationTagConflictService.normalizeUserTags(context.userTags());
+        boolean quietPreferredByTag = normalizedUserTags.stream().anyMatch(QUIET_PREFERENCE_TAGS::contains);
+        boolean quietPreferredByContext = environmentContext != null && environmentContext.prefersQuietPlace();
+        boolean quietPreferred = quietPreferredByTag || quietPreferredByContext;
+        boolean quietMatched = hasNormalizedTag(place.getTags(), "QUIET");
+
+        if (!quietPreferred) {
+            return component(
+                    "QUIET_PREFERENCE",
+                    QUIET_PREFERENCE_WEIGHT,
+                    0.0,
+                    "no quiet preference tag"
+            );
+        }
+
+        double score = 0.0;
+        if (quietMatched) {
+            if (quietPreferredByTag) {
+                score = QUIET_PREFERENCE_WEIGHT;
+            } else if (environmentContext != null && environmentContext.isIntrovert()) {
+                score = QUIET_PREFERENCE_WEIGHT;
+            } else if (environmentContext != null && environmentContext.isExtrovert()) {
+                score = 6.0;
+            } else {
+                score = 8.0;
+            }
+        }
+
+        return component(
+                "QUIET_PREFERENCE",
+                QUIET_PREFERENCE_WEIGHT,
+                score,
+                quietMatched
+                        ? quietPreferenceDetail(quietPreferredByTag, quietPreferredByContext, environmentContext)
+                        : "quiet preference requested but place tag QUIET missing"
+        );
+    }
+
+    private ScoreComponent buildDataSourceComponent(Place place, PlaceRankingContext context) {
+        DataSource source = place.getDataSource() != null ? place.getDataSource() : DataSource.MANUAL;
+        double baseScore = switch (source) {
+            case KOPIS, SEOUL_CULTURE, MANUAL -> 10.0;
+            case SEOUL_RESERVATION, SEOUL_RESTAURANT -> 9.0;
+            case SEOUL_PARK -> 8.0;
+            case LIBRARY -> roundScore(DATA_SOURCE_WEIGHT
+                    * recommendationSupportService.resolveLibrarySourceWeight(context.environmentContext()));
+        };
+        double preferenceWeight = context.preferenceProfile() != null
+                ? context.preferenceProfile().dataSourceWeight(source)
+                : 1.0;
+        double score = applyPreferenceWeight(DATA_SOURCE_WEIGHT, baseScore, preferenceWeight);
+
+        return component(
+                "DATA_SOURCE",
+                DATA_SOURCE_WEIGHT,
+                score,
+                source == DataSource.LIBRARY
+                        ? "dataSource=" + source + ","
+                            + recommendationSupportService.describeLibrarySourceWeight(context.environmentContext())
+                            + ",preferenceWeight=" + preferenceWeight
+                        : "dataSource=" + source + ",preferenceWeight=" + preferenceWeight
+        );
+    }
+
+    private String quietPreferenceDetail(boolean quietPreferredByTag,
+                                         boolean quietPreferredByContext,
+                                         EnvironmentContext environmentContext) {
+        if (quietPreferredByTag && quietPreferredByContext) {
+            return "quiet preference matched via user tag and congestion context";
+        }
+
+        if (quietPreferredByTag) {
+            return "quiet preference matched via user tag";
+        }
+
+        if (environmentContext != null && environmentContext.isIntrovert()) {
+            return "quiet preference matched via HIGH congestion + introvert";
+        }
+
+        if (environmentContext != null && environmentContext.isExtrovert()) {
+            return "quiet preference matched via HIGH congestion + extrovert";
+        }
+
+        return "quiet preference matched via congestion context";
+    }
+
+    private Integer resolveTicketPrice(Place place) {
+        PlaceDetailPerformance performanceDetail = place.getPerformanceDetail();
+        if (performanceDetail != null && performanceDetail.getTicketPrice() != null) {
+            return performanceDetail.getTicketPrice();
+        }
+        return place.getTicketPrice();
+    }
+
+    private boolean isTypicallyFreeSource(DataSource dataSource) {
+        return dataSource == DataSource.LIBRARY || dataSource == DataSource.SEOUL_PARK;
+    }
+
+    private boolean hasNormalizedTag(String tags, String expectedTag) {
+        if (tags == null || tags.isBlank()) {
+            return false;
+        }
+
+        for (String token : tags.split(",")) {
+            if (expectedTag.equals(token.trim().toUpperCase(Locale.ROOT))) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private Double extractDistanceKm(Place place, Double userLatitude, Double userLongitude) {
+        if (userLatitude == null || userLongitude == null
+                || place.getLatitude() == null || place.getLongitude() == null) {
+            return null;
+        }
+
+        return roundScore(calculateDistanceKm(
+                userLatitude,
+                userLongitude,
+                place.getLatitude(),
+                place.getLongitude()
+        ));
+    }
+
+    private double calculateDistanceKm(double lat1, double lon1, double lat2, double lon2) {
+        final double earthRadiusKm = 6371.0;
+
+        double latitudeDelta = Math.toRadians(lat2 - lat1);
+        double longitudeDelta = Math.toRadians(lon2 - lon1);
+        double a = Math.sin(latitudeDelta / 2) * Math.sin(latitudeDelta / 2)
+                + Math.cos(Math.toRadians(lat1)) * Math.cos(Math.toRadians(lat2))
+                * Math.sin(longitudeDelta / 2) * Math.sin(longitudeDelta / 2);
+        double c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+        return earthRadiusKm * c;
+    }
+
+    private ScoreComponent component(String code, double weight, double score, String detail) {
+        return new ScoreComponent(code, roundScore(weight), roundScore(score), detail);
+    }
+
+    private double applyPreferenceWeight(double maxScore, double baseScore, double preferenceWeight) {
+        double normalizedWeight = Math.max(0.7, Math.min(1.25, preferenceWeight));
+        return roundScore(Math.min(maxScore, baseScore * normalizedWeight));
+    }
+
+    private double roundScore(double value) {
+        return Math.round(value * 10.0) / 10.0;
+    }
+
+    public record PlaceRankingContext(
+            MissionCategory missionCategory,
+            String userTags,
+            Double userLatitude,
+            Double userLongitude,
+            Integer distanceRadiusKm,
+            EnvironmentContext environmentContext,
+            RecommendationPreferenceService.UserPreferenceProfile preferenceProfile
+    ) {
+    }
+
+    public record ScoreComponent(
+            String code,
+            double weight,
+            double score,
+            String detail
+    ) {
+    }
+
+    public record PlaceScore(
+            Place place,
+            double totalScore,
+            Double distanceKm,
+            List<ScoreComponent> components
+    ) {
+    }
+
+    public record PlaceSelectionResult(
+            PlaceScore selected,
+            List<PlaceScore> rankedCandidates,
+            int tieCandidateCount,
+            boolean tieBreakApplied
+    ) {
+    }
+}

--- a/backend/src/main/java/com/littleescape/api/service/PlaceScheduleFilterService.java
+++ b/backend/src/main/java/com/littleescape/api/service/PlaceScheduleFilterService.java
@@ -1,0 +1,654 @@
+package com.littleescape.api.service;
+
+import com.littleescape.api.domain.Place;
+import com.littleescape.api.domain.PlaceDetailFacility;
+import org.springframework.stereotype.Service;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+@Service
+public class PlaceScheduleFilterService {
+
+    private static final LocalTime DEFAULT_DATE_ONLY_TIME = LocalTime.NOON;
+    private static final Pattern TIME_RANGE_PATTERN = Pattern.compile(
+            "(\\d{1,2})(?::(\\d{2}))?\\s*(?:\\uC2DC)?\\s*[-~]\\s*(\\d{1,2})(?::(\\d{2}))?\\s*(?:\\uC2DC)?"
+    );
+    private static final Pattern DAY_RANGE_PATTERN = Pattern.compile(
+            "\\b(MON|TUE|WED|THU|FRI|SAT|SUN)\\b\\s*[-~]\\s*\\b(MON|TUE|WED|THU|FRI|SAT|SUN)\\b"
+    );
+
+    public PlaceScheduleFilterResult filterPlacesBySchedule(
+            List<Place> places,
+            LocalDate targetDate,
+            LocalDate today
+    ) {
+        LocalDate effectiveTargetDate = targetDate != null ? targetDate : LocalDate.now();
+        return filterPlacesBySchedule(
+                places,
+                LocalDateTime.of(effectiveTargetDate, DEFAULT_DATE_ONLY_TIME),
+                today
+        );
+    }
+
+    public PlaceScheduleFilterResult filterPlacesBySchedule(
+            List<Place> places,
+            LocalDateTime targetDateTime,
+            LocalDate today
+    ) {
+        if (places.isEmpty()) {
+            return new PlaceScheduleFilterResult(
+                    new ArrayList<>(),
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    List.of()
+            );
+        }
+
+        LocalDateTime effectiveTargetDateTime = targetDateTime != null ? targetDateTime : LocalDateTime.now();
+        LocalDate effectiveTargetDate = effectiveTargetDateTime.toLocalDate();
+        LocalDate effectiveToday = today != null ? today : LocalDate.now();
+
+        int beforeCount = places.size();
+        int deactivatedCount = 0;
+        int expiredCount = 0;
+        int notStartedCount = 0;
+        int closedDayCount = 0;
+        int outsideOperatingHoursCount = 0;
+        int unavailableOperationInfoCount = 0;
+        int unknownOperationalInfoCount = 0;
+
+        List<Place> filteredPlaces = new ArrayList<>();
+        List<ScheduleFilterDecision> exclusionDetails = new ArrayList<>();
+
+        for (Place place : places) {
+            LocalDate startDate = getPlaceStartDate(place);
+            LocalDate endDate = getPlaceEndDate(place);
+
+            if (endDate != null && endDate.isBefore(effectiveToday)) {
+                place.deactivate();
+                deactivatedCount++;
+                exclusionDetails.add(decision(
+                        place,
+                        "DEACTIVATE_EXPIRED_PERFORMANCE",
+                        "endDate=" + endDate + ", today=" + effectiveToday
+                ));
+                continue;
+            }
+
+            boolean afterStart = startDate == null || !effectiveTargetDate.isBefore(startDate);
+            boolean beforeEnd = endDate == null || !effectiveTargetDate.isAfter(endDate);
+            if (!afterStart || !beforeEnd) {
+                if (!afterStart) {
+                    notStartedCount++;
+                    exclusionDetails.add(decision(
+                            place,
+                            "EXCLUDE_NOT_YET_STARTED",
+                            "targetDate=" + effectiveTargetDate + ", startDate=" + startDate
+                    ));
+                } else {
+                    expiredCount++;
+                    exclusionDetails.add(decision(
+                            place,
+                            "EXCLUDE_OUTSIDE_SCHEDULE_DATE",
+                            "targetDate=" + effectiveTargetDate + ", endDate=" + endDate
+                    ));
+                }
+                continue;
+            }
+
+            OperationalAvailability availability = evaluateOperationalAvailability(place, effectiveTargetDateTime);
+            if (!availability.available()) {
+                switch (availability.reasonCode()) {
+                    case "EXCLUDE_CLOSED_DAY" -> closedDayCount++;
+                    case "EXCLUDE_OUTSIDE_OPERATING_HOURS" -> outsideOperatingHoursCount++;
+                    default -> unavailableOperationInfoCount++;
+                }
+                exclusionDetails.add(decision(place, availability.reasonCode(), availability.detail()));
+                continue;
+            }
+
+            if (availability.unknown()) {
+                unknownOperationalInfoCount++;
+            }
+            filteredPlaces.add(place);
+        }
+
+        return new PlaceScheduleFilterResult(
+                filteredPlaces,
+                beforeCount,
+                filteredPlaces.size(),
+                deactivatedCount,
+                expiredCount,
+                notStartedCount,
+                closedDayCount,
+                outsideOperatingHoursCount,
+                unavailableOperationInfoCount,
+                unknownOperationalInfoCount,
+                List.copyOf(exclusionDetails)
+        );
+    }
+
+    private OperationalAvailability evaluateOperationalAvailability(Place place, LocalDateTime targetDateTime) {
+        String operatingTime = getOperatingTime(place);
+        String closedDays = getClosedDays(place);
+        boolean hasOperationalInfo = hasText(operatingTime) || hasText(closedDays);
+
+        if (!hasOperationalInfo) {
+            return OperationalAvailability.available(false);
+        }
+
+        String normalizedCombined = normalizeOperationalText((closedDays == null ? "" : closedDays) + " " +
+                (operatingTime == null ? "" : operatingTime));
+        if (containsAny(normalizedCombined,
+                "TEMPORARILY CLOSED",
+                "CLOSED PERMANENTLY",
+                "PERMANENTLY CLOSED",
+                "운영종료",
+                "영업종료",
+                "임시휴관",
+                "임시휴업",
+                "운영중단",
+                "휴업",
+                "폐업",
+                "미운영")) {
+            return OperationalAvailability.unavailable(
+                    "EXCLUDE_CLEARLY_UNAVAILABLE_OPERATION_INFO",
+                    "operationalStatus=" + summarizeRaw(closedDays, operatingTime),
+                    false
+            );
+        }
+
+        DayEvaluation closedDayEvaluation = evaluateClosedDays(closedDays, targetDateTime.toLocalDate());
+        if (closedDayEvaluation.closed()) {
+            return OperationalAvailability.unavailable(
+                    "EXCLUDE_CLOSED_DAY",
+                    closedDayEvaluation.detail(),
+                    false
+            );
+        }
+
+        OperatingHoursEvaluation operatingHoursEvaluation = evaluateOperatingHours(operatingTime, targetDateTime);
+        if (operatingHoursEvaluation.closed()) {
+            return OperationalAvailability.unavailable(
+                    "EXCLUDE_OUTSIDE_OPERATING_HOURS",
+                    operatingHoursEvaluation.detail(),
+                    false
+            );
+        }
+
+        boolean unknown = closedDayEvaluation.unknown() || operatingHoursEvaluation.unknown();
+        return OperationalAvailability.available(unknown);
+    }
+
+    private DayEvaluation evaluateClosedDays(String closedDays, LocalDate targetDate) {
+        if (!hasText(closedDays)) {
+            return DayEvaluation.available(false, "no closed-day info");
+        }
+
+        String normalized = normalizeOperationalText(closedDays);
+        if (containsAny(normalized,
+                "EVERYDAY",
+                "연중무휴",
+                "무휴",
+                "휴무없음",
+                "휴무 없음",
+                "휴관없음",
+                "휴관 없음",
+                "정기휴무없음",
+                "정기휴무 없음",
+                "NONE",
+                "없음")) {
+            return DayEvaluation.available(false, "always open");
+        }
+
+        if (containsAny(normalized, "HOLIDAY", "공휴일")) {
+            return DayEvaluation.available(true, "holiday closure only");
+        }
+
+        if (matchesQualifiedClosedDay(normalized, targetDate)) {
+            return DayEvaluation.closed("closedDays=" + closedDays);
+        }
+
+        if (containsMonthlyQualifier(normalized)) {
+            return DayEvaluation.available(true, "monthly closure rule did not match target date");
+        }
+
+        if (appliesToDay(normalized, targetDate.getDayOfWeek())) {
+            return DayEvaluation.closed("closedDays=" + closedDays);
+        }
+
+        if (containsDayReference(normalized)) {
+            return DayEvaluation.available(false, "other day closed");
+        }
+
+        return DayEvaluation.available(true, "unparsed closedDays=" + closedDays);
+    }
+
+    private OperatingHoursEvaluation evaluateOperatingHours(String operatingTime, LocalDateTime targetDateTime) {
+        if (!hasText(operatingTime)) {
+            return OperatingHoursEvaluation.available(false, "no operating-time info");
+        }
+
+        String normalized = normalizeOperationalText(operatingTime);
+        if (containsAny(normalized, "24 HOURS", "24H", "24시간", "연중무휴", "상시운영")) {
+            return OperatingHoursEvaluation.available(false, "always open");
+        }
+
+        if (containsAny(normalized, "운영종료", "영업종료", "임시휴관", "임시휴업", "운영중단", "폐업", "미운영")
+                && !TIME_RANGE_PATTERN.matcher(normalized).find()) {
+            return OperatingHoursEvaluation.closed("operatingTime=" + operatingTime);
+        }
+
+        String[] segments = normalized.split("\\s*/\\s*|\\s*;\\s*|\\R|,(?=\\s*(MON|TUE|WED|THU|FRI|SAT|SUN|WEEKDAY|WEEKEND|EVERYDAY))");
+        List<String> applicableSegments = new ArrayList<>();
+        List<String> genericSegments = new ArrayList<>();
+        List<String> breakSegments = new ArrayList<>();
+
+        for (String rawSegment : segments) {
+            String segment = rawSegment.trim();
+            if (segment.isEmpty()) {
+                continue;
+            }
+
+            DayApplicability applicability = classifyDayApplicability(segment, targetDateTime.getDayOfWeek());
+            if (applicability == DayApplicability.DOES_NOT_APPLY) {
+                continue;
+            }
+
+            boolean isBreakSegment = containsAny(segment, "BREAK", "브레이크", "휴게", "점심");
+            if (isBreakSegment) {
+                breakSegments.add(segment);
+                continue;
+            }
+
+            if (applicability == DayApplicability.APPLIES) {
+                applicableSegments.add(segment);
+            } else {
+                genericSegments.add(segment);
+            }
+        }
+
+        List<String> selectedSegments = !applicableSegments.isEmpty() ? applicableSegments : genericSegments;
+        List<TimeRange> operatingRanges = extractTimeRanges(selectedSegments);
+
+        if (operatingRanges.isEmpty()) {
+            return OperatingHoursEvaluation.available(true, "unparsed operatingTime=" + operatingTime);
+        }
+
+        int targetMinutes = toMinutes(targetDateTime.toLocalTime());
+        boolean withinOperatingHours = operatingRanges.stream().anyMatch(range -> range.contains(targetMinutes));
+        if (!withinOperatingHours) {
+            return OperatingHoursEvaluation.closed("operatingTime=" + operatingTime + ", targetTime=" + targetDateTime.toLocalTime());
+        }
+
+        List<TimeRange> breakRanges = extractTimeRanges(breakSegments);
+        boolean withinBreak = breakRanges.stream().anyMatch(range -> range.contains(targetMinutes));
+        if (withinBreak) {
+            return OperatingHoursEvaluation.closed("breakTime=" + operatingTime + ", targetTime=" + targetDateTime.toLocalTime());
+        }
+
+        return OperatingHoursEvaluation.available(false, "within operating hours");
+    }
+
+    private boolean matchesQualifiedClosedDay(String normalizedClosedDays, LocalDate targetDate) {
+        if (!containsDayToken(normalizedClosedDays, tokenFor(targetDate.getDayOfWeek()))) {
+            return false;
+        }
+
+        int occurrence = ((targetDate.getDayOfMonth() - 1) / 7) + 1;
+        boolean isLast = targetDate.plusWeeks(1).getMonth() != targetDate.getMonth();
+
+        return (normalizedClosedDays.contains("FIRST") && occurrence == 1)
+                || (normalizedClosedDays.contains("SECOND") && occurrence == 2)
+                || (normalizedClosedDays.contains("THIRD") && occurrence == 3)
+                || (normalizedClosedDays.contains("FOURTH") && occurrence == 4)
+                || (normalizedClosedDays.contains("FIFTH") && occurrence == 5)
+                || (normalizedClosedDays.contains("LAST") && isLast);
+    }
+
+    private boolean containsMonthlyQualifier(String normalizedClosedDays) {
+        return containsAny(normalizedClosedDays, "MONTHLY", "FIRST", "SECOND", "THIRD", "FOURTH", "FIFTH", "LAST");
+    }
+
+    private List<TimeRange> extractTimeRanges(List<String> segments) {
+        List<TimeRange> ranges = new ArrayList<>();
+        for (String segment : segments) {
+            Matcher matcher = TIME_RANGE_PATTERN.matcher(segment);
+            while (matcher.find()) {
+                Integer start = parseMinutes(matcher.group(1), matcher.group(2));
+                Integer end = parseMinutes(matcher.group(3), matcher.group(4));
+                if (start != null && end != null) {
+                    ranges.add(new TimeRange(start, end));
+                }
+            }
+        }
+        return ranges;
+    }
+
+    private Integer parseMinutes(String hourText, String minuteText) {
+        try {
+            int hour = Integer.parseInt(hourText);
+            int minute = minuteText != null ? Integer.parseInt(minuteText) : 0;
+            if (hour == 24 && minute == 0) {
+                return 24 * 60;
+            }
+            if (hour < 0 || hour > 23 || minute < 0 || minute > 59) {
+                return null;
+            }
+            return (hour * 60) + minute;
+        } catch (NumberFormatException e) {
+            return null;
+        }
+    }
+
+    private DayApplicability classifyDayApplicability(String normalizedSegment, DayOfWeek targetDay) {
+        String targetToken = tokenFor(targetDay);
+
+        if (containsAny(normalizedSegment, "EVERYDAY")) {
+            return DayApplicability.APPLIES;
+        }
+
+        if (targetDay.getValue() <= DayOfWeek.FRIDAY.getValue() && containsAny(normalizedSegment, "WEEKDAY")) {
+            return DayApplicability.APPLIES;
+        }
+
+        if (targetDay == DayOfWeek.SATURDAY || targetDay == DayOfWeek.SUNDAY) {
+            if (containsAny(normalizedSegment, "WEEKEND")) {
+                return DayApplicability.APPLIES;
+            }
+        }
+
+        Matcher matcher = DAY_RANGE_PATTERN.matcher(normalizedSegment);
+        while (matcher.find()) {
+            DayOfWeek start = dayOfWeekFor(matcher.group(1));
+            DayOfWeek end = dayOfWeekFor(matcher.group(2));
+            if (start != null && end != null && isWithinDayRange(targetDay, start, end)) {
+                return DayApplicability.APPLIES;
+            }
+        }
+
+        if (containsDayToken(normalizedSegment, targetToken)) {
+            return DayApplicability.APPLIES;
+        }
+
+        return containsDayReference(normalizedSegment) ? DayApplicability.DOES_NOT_APPLY : DayApplicability.GENERIC;
+    }
+
+    private boolean isWithinDayRange(DayOfWeek target, DayOfWeek start, DayOfWeek end) {
+        int targetValue = target.getValue();
+        int startValue = start.getValue();
+        int endValue = end.getValue();
+        if (startValue <= endValue) {
+            return targetValue >= startValue && targetValue <= endValue;
+        }
+        return targetValue >= startValue || targetValue <= endValue;
+    }
+
+    private boolean containsDayReference(String normalizedText) {
+        return containsAny(normalizedText,
+                "MON", "TUE", "WED", "THU", "FRI", "SAT", "SUN",
+                "WEEKDAY", "WEEKEND", "EVERYDAY");
+    }
+
+    private boolean appliesToDay(String normalizedText, DayOfWeek dayOfWeek) {
+        return classifyDayApplicability(normalizedText, dayOfWeek) == DayApplicability.APPLIES;
+    }
+
+    private boolean containsDayToken(String normalizedText, String token) {
+        return normalizedText.contains(" " + token + " ")
+                || normalizedText.startsWith(token + " ")
+                || normalizedText.endsWith(" " + token)
+                || normalizedText.equals(token);
+    }
+
+    private String tokenFor(DayOfWeek dayOfWeek) {
+        return switch (dayOfWeek) {
+            case MONDAY -> "MON";
+            case TUESDAY -> "TUE";
+            case WEDNESDAY -> "WED";
+            case THURSDAY -> "THU";
+            case FRIDAY -> "FRI";
+            case SATURDAY -> "SAT";
+            case SUNDAY -> "SUN";
+        };
+    }
+
+    private DayOfWeek dayOfWeekFor(String token) {
+        return switch (token) {
+            case "MON" -> DayOfWeek.MONDAY;
+            case "TUE" -> DayOfWeek.TUESDAY;
+            case "WED" -> DayOfWeek.WEDNESDAY;
+            case "THU" -> DayOfWeek.THURSDAY;
+            case "FRI" -> DayOfWeek.FRIDAY;
+            case "SAT" -> DayOfWeek.SATURDAY;
+            case "SUN" -> DayOfWeek.SUNDAY;
+            default -> null;
+        };
+    }
+
+    private int toMinutes(LocalTime time) {
+        return (time.getHour() * 60) + time.getMinute();
+    }
+
+    private String normalizeOperationalText(String raw) {
+        if (!hasText(raw)) {
+            return "";
+        }
+
+        String normalized = raw.toUpperCase(Locale.ROOT)
+                .replace('∼', '~')
+                .replace('～', '~')
+                .replace('–', '-')
+                .replace('—', '-')
+                .replace("부터", "-")
+                .replace("까지", "")
+                .replace("매월", " MONTHLY ")
+                .replace("첫째", " FIRST ")
+                .replace("둘째", " SECOND ")
+                .replace("셋째", " THIRD ")
+                .replace("넷째", " FOURTH ")
+                .replace("다섯째", " FIFTH ")
+                .replace("마지막", " LAST ")
+                .replace("월요일", " MON ")
+                .replace("화요일", " TUE ")
+                .replace("수요일", " WED ")
+                .replace("목요일", " THU ")
+                .replace("금요일", " FRI ")
+                .replace("토요일", " SAT ")
+                .replace("일요일", " SUN ")
+                .replace("평일", " WEEKDAY ")
+                .replace("주말", " WEEKEND ")
+                .replace("매일", " EVERYDAY ")
+                .replace("MONDAY", " MON ")
+                .replace("TUESDAY", " TUE ")
+                .replace("WEDNESDAY", " WED ")
+                .replace("THURSDAY", " THU ")
+                .replace("FRIDAY", " FRI ")
+                .replace("SATURDAY", " SAT ")
+                .replace("SUNDAY", " SUN ")
+                .replace("WEEKDAYS", " WEEKDAY ")
+                .replace("WEEKENDS", " WEEKEND ")
+                .replace("DAILY", " EVERYDAY ")
+                .replace("TO", "-");
+
+        normalized = replaceStandaloneDayToken(normalized, "월", "MON");
+        normalized = replaceStandaloneDayToken(normalized, "화", "TUE");
+        normalized = replaceStandaloneDayToken(normalized, "수", "WED");
+        normalized = replaceStandaloneDayToken(normalized, "목", "THU");
+        normalized = replaceStandaloneDayToken(normalized, "금", "FRI");
+        normalized = replaceStandaloneDayToken(normalized, "토", "SAT");
+        normalized = replaceStandaloneDayToken(normalized, "일", "SUN");
+
+        normalized = normalized.replaceAll("\\s+", " ").trim();
+        return " " + normalized + " ";
+    }
+
+    private String replaceStandaloneDayToken(String text, String dayChar, String token) {
+        return text.replaceAll("(^|[\\s,./()\\[\\]-])" + dayChar + "(?=$|[\\s,./()\\[\\]~-])", "$1 " + token + " ");
+    }
+
+    private boolean containsAny(String text, String... keywords) {
+        for (String keyword : keywords) {
+            if (text.contains(keyword)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private boolean hasText(String value) {
+        return value != null && !value.isBlank();
+    }
+
+    private String summarizeRaw(String closedDays, String operatingTime) {
+        StringBuilder builder = new StringBuilder();
+        if (hasText(closedDays)) {
+            builder.append("closedDays=").append(closedDays);
+        }
+        if (hasText(operatingTime)) {
+            if (builder.length() > 0) {
+                builder.append(", ");
+            }
+            builder.append("operatingTime=").append(operatingTime);
+        }
+        return builder.toString();
+    }
+
+    private LocalDate getPlaceStartDate(Place place) {
+        if (place.getPerformanceDetail() != null && place.getPerformanceDetail().getStartDate() != null) {
+            return place.getPerformanceDetail().getStartDate();
+        }
+        return place.getStartDate();
+    }
+
+    private LocalDate getPlaceEndDate(Place place) {
+        if (place.getPerformanceDetail() != null && place.getPerformanceDetail().getEndDate() != null) {
+            return place.getPerformanceDetail().getEndDate();
+        }
+        return place.getEndDate();
+    }
+
+    private String getOperatingTime(Place place) {
+        PlaceDetailFacility facilityDetail = place.getFacilityDetail();
+        if (facilityDetail != null && hasText(facilityDetail.getOperatingTime())) {
+            return facilityDetail.getOperatingTime();
+        }
+        return place.getOperatingTime();
+    }
+
+    private String getClosedDays(Place place) {
+        PlaceDetailFacility facilityDetail = place.getFacilityDetail();
+        if (facilityDetail != null && hasText(facilityDetail.getClosedDays())) {
+            return facilityDetail.getClosedDays();
+        }
+        return place.getClosedDays();
+    }
+
+    private ScheduleFilterDecision decision(Place place, String reasonCode, String detail) {
+        return new ScheduleFilterDecision(
+                place.getId(),
+                place.getName(),
+                reasonCode,
+                detail
+        );
+    }
+
+    private enum DayApplicability {
+        APPLIES,
+        DOES_NOT_APPLY,
+        GENERIC
+    }
+
+    private record OperationalAvailability(
+            boolean available,
+            boolean unknown,
+            String reasonCode,
+            String detail
+    ) {
+        private static OperationalAvailability available(boolean unknown) {
+            return new OperationalAvailability(true, unknown, null, null);
+        }
+
+        private static OperationalAvailability unavailable(String reasonCode, String detail, boolean unknown) {
+            return new OperationalAvailability(false, unknown, reasonCode, detail);
+        }
+    }
+
+    private record DayEvaluation(
+            boolean closed,
+            boolean unknown,
+            String detail
+    ) {
+        private static DayEvaluation closed(String detail) {
+            return new DayEvaluation(true, false, detail);
+        }
+
+        private static DayEvaluation available(boolean unknown, String detail) {
+            return new DayEvaluation(false, unknown, detail);
+        }
+    }
+
+    private record OperatingHoursEvaluation(
+            boolean closed,
+            boolean unknown,
+            String detail
+    ) {
+        private static OperatingHoursEvaluation closed(String detail) {
+            return new OperatingHoursEvaluation(true, false, detail);
+        }
+
+        private static OperatingHoursEvaluation available(boolean unknown, String detail) {
+            return new OperatingHoursEvaluation(false, unknown, detail);
+        }
+    }
+
+    private record TimeRange(int startMinutes, int endMinutes) {
+        private boolean contains(int targetMinutes) {
+            if (endMinutes == startMinutes) {
+                return true;
+            }
+            if (endMinutes > startMinutes) {
+                return targetMinutes >= startMinutes && targetMinutes < endMinutes;
+            }
+            return targetMinutes >= startMinutes || targetMinutes < endMinutes;
+        }
+    }
+
+    public record ScheduleFilterDecision(
+            Long placeId,
+            String placeName,
+            String reasonCode,
+            String detail
+    ) {
+    }
+
+    public record PlaceScheduleFilterResult(
+            List<Place> filteredPlaces,
+            int beforeCount,
+            int afterCount,
+            int deactivatedCount,
+            int expiredCount,
+            int notStartedCount,
+            int closedDayCount,
+            int outsideOperatingHoursCount,
+            int unavailableOperationInfoCount,
+            int unknownOperationalInfoCount,
+            List<ScheduleFilterDecision> exclusionDetails
+    ) {
+    }
+}

--- a/backend/src/main/java/com/littleescape/api/service/RecommendationEnvironmentService.java
+++ b/backend/src/main/java/com/littleescape/api/service/RecommendationEnvironmentService.java
@@ -1,0 +1,143 @@
+package com.littleescape.api.service;
+
+import com.littleescape.api.domain.SeoulCityPlace;
+import com.littleescape.api.domain.type.AirQuality;
+import com.littleescape.api.domain.type.Congestion;
+import com.littleescape.api.domain.type.CongestionLevel;
+import com.littleescape.api.domain.type.Weather;
+import com.littleescape.api.service.simulation.EnvironmentContext;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+
+@Service
+@RequiredArgsConstructor
+public class RecommendationEnvironmentService {
+
+    private static final int MAX_REALTIME_CACHE_AGE_MINUTES = 90;
+    private static final int PM25_BAD_THRESHOLD = 35;
+    private static final int PM25_WORST_THRESHOLD = 75;
+    private static final int PM10_BAD_THRESHOLD = 80;
+    private static final int PM10_WORST_THRESHOLD = 150;
+
+    private final SeoulCityPlaceCacheService seoulCityPlaceCacheService;
+
+    public EnvironmentContext buildRealTimeContext(
+            LocalDateTime targetDateTime,
+            Double latitude,
+            Double longitude,
+            Integer searchRadius,
+            String userMbti,
+            String userTags
+    ) {
+        RealTimeEnvironmentSnapshot snapshot = resolveSnapshot(latitude, longitude);
+
+        return EnvironmentContext.fromRealTime(
+                targetDateTime,
+                latitude,
+                longitude,
+                searchRadius,
+                snapshot.weather(),
+                snapshot.temperature(),
+                snapshot.airQuality(),
+                snapshot.congestion(),
+                userMbti,
+                userTags
+        );
+    }
+
+    public EnvironmentContext buildRealTimeContext(
+            LocalDateTime targetDateTime,
+            Double latitude,
+            Double longitude,
+            String userMbti,
+            String userTags
+    ) {
+        return buildRealTimeContext(targetDateTime, latitude, longitude, null, userMbti, userTags);
+    }
+
+    public RealTimeEnvironmentSnapshot resolveSnapshot(Double latitude, Double longitude) {
+        if (latitude == null || longitude == null) {
+            return fallbackSnapshot("fallback:no_coordinates");
+        }
+
+        return seoulCityPlaceCacheService.getNearestPlace(latitude, longitude)
+                .filter(place -> place.isFresh(MAX_REALTIME_CACHE_AGE_MINUTES))
+                .map(this::snapshotFromPlace)
+                .orElseGet(() -> fallbackSnapshot("fallback:no_fresh_city_data"));
+    }
+
+    private RealTimeEnvironmentSnapshot snapshotFromPlace(SeoulCityPlace place) {
+        return new RealTimeEnvironmentSnapshot(
+                mapWeather(place),
+                place.getTemperature() != null
+                        ? place.getTemperature()
+                        : EnvironmentContext.DEFAULT_REALTIME_TEMPERATURE_C,
+                mapAirQuality(place),
+                mapCongestion(place.getCongestionLevel()),
+                "seoul_city_cache:" + place.getPlaceName()
+        );
+    }
+
+    private RealTimeEnvironmentSnapshot fallbackSnapshot(String source) {
+        return new RealTimeEnvironmentSnapshot(
+                EnvironmentContext.DEFAULT_REALTIME_WEATHER,
+                EnvironmentContext.DEFAULT_REALTIME_TEMPERATURE_C,
+                EnvironmentContext.DEFAULT_REALTIME_AIR_QUALITY,
+                EnvironmentContext.DEFAULT_REALTIME_CONGESTION,
+                source
+        );
+    }
+
+    private Weather mapWeather(SeoulCityPlace place) {
+        if (place.isSnowy()) {
+            return Weather.SNOW;
+        }
+        if (place.isRainy()) {
+            return Weather.RAIN;
+        }
+        if (place.isClearWeather()) {
+            return Weather.SUNNY;
+        }
+        return Weather.CLOUDY;
+    }
+
+    private AirQuality mapAirQuality(SeoulCityPlace place) {
+        Integer pm25 = place.getPm25();
+        Integer pm10 = place.getPm10();
+
+        if ((pm25 != null && pm25 > PM25_WORST_THRESHOLD)
+                || (pm10 != null && pm10 > PM10_WORST_THRESHOLD)) {
+            return AirQuality.WORST;
+        }
+
+        if ((pm25 != null && pm25 > PM25_BAD_THRESHOLD)
+                || (pm10 != null && pm10 > PM10_BAD_THRESHOLD)) {
+            return AirQuality.BAD;
+        }
+
+        return EnvironmentContext.DEFAULT_REALTIME_AIR_QUALITY;
+    }
+
+    private Congestion mapCongestion(CongestionLevel congestionLevel) {
+        if (congestionLevel == null) {
+            return EnvironmentContext.DEFAULT_REALTIME_CONGESTION;
+        }
+
+        return switch (congestionLevel) {
+            case SMOOTH -> Congestion.LOW;
+            case NORMAL, SLIGHTLY_CROWDED -> Congestion.NORMAL;
+            case CROWDED, VERY_CROWDED -> Congestion.HIGH;
+        };
+    }
+
+    public record RealTimeEnvironmentSnapshot(
+            Weather weather,
+            Double temperature,
+            AirQuality airQuality,
+            Congestion congestion,
+            String source
+    ) {
+    }
+}

--- a/backend/src/main/java/com/littleescape/api/service/RecommendationPreferenceService.java
+++ b/backend/src/main/java/com/littleescape/api/service/RecommendationPreferenceService.java
@@ -1,0 +1,256 @@
+package com.littleescape.api.service;
+
+import com.littleescape.api.domain.type.AppointmentStatus;
+import com.littleescape.api.domain.type.DataSource;
+import com.littleescape.api.domain.type.MissionCategory;
+import com.littleescape.api.repository.AppointmentRepository;
+import com.littleescape.api.repository.LikedAppointmentRepository;
+import com.littleescape.api.repository.SavedAppointmentRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.EnumMap;
+import java.util.List;
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+public class RecommendationPreferenceService {
+
+    private static final double DEFAULT_WEIGHT = 1.0;
+    private static final double MIN_WEIGHT = 0.35;
+    private static final double MAX_WEIGHT = 2.25;
+
+    private final SavedAppointmentRepository savedAppointmentRepository;
+    private final LikedAppointmentRepository likedAppointmentRepository;
+    private final AppointmentRepository appointmentRepository;
+
+    public UserPreferenceProfile buildProfile(Long userId) {
+        Map<MissionCategory, Double> categoryWeights = new EnumMap<>(MissionCategory.class);
+        for (MissionCategory category : MissionCategory.values()) {
+            categoryWeights.put(category, DEFAULT_WEIGHT);
+        }
+
+        Map<DataSource, Double> dataSourceWeights = new EnumMap<>(DataSource.class);
+        for (DataSource dataSource : DataSource.values()) {
+            dataSourceWeights.put(dataSource, DEFAULT_WEIGHT);
+        }
+
+        List<PreferenceSignal> signals = new ArrayList<>();
+
+        applyCategorySignal(
+                categoryWeights,
+                signals,
+                "saved",
+                savedAppointmentRepository.findCategoryStatsByUserId(userId),
+                0.9,
+                5.0,
+                false
+        );
+        applyCategorySignal(
+                categoryWeights,
+                signals,
+                "liked",
+                likedAppointmentRepository.findCategoryStatsByUserId(userId),
+                0.7,
+                4.0,
+                false
+        );
+        applyCategorySignal(
+                categoryWeights,
+                signals,
+                "completed",
+                appointmentRepository.findCategoryStatsByUserIdAndStatuses(
+                        userId,
+                        List.of(AppointmentStatus.COMPLETED)
+                ),
+                0.6,
+                6.0,
+                false
+        );
+        applyCategorySignal(
+                categoryWeights,
+                signals,
+                "cancelled",
+                appointmentRepository.findCategoryStatsByUserIdAndStatuses(
+                        userId,
+                        List.of(AppointmentStatus.CANCELLED)
+                ),
+                0.8,
+                4.0,
+                true
+        );
+
+        applyDataSourceSignal(
+                dataSourceWeights,
+                signals,
+                "saved",
+                savedAppointmentRepository.findPlaceDataSourceStatsByUserId(userId),
+                0.35,
+                4.0,
+                false
+        );
+        applyDataSourceSignal(
+                dataSourceWeights,
+                signals,
+                "liked",
+                likedAppointmentRepository.findPlaceDataSourceStatsByUserId(userId),
+                0.30,
+                4.0,
+                false
+        );
+        applyDataSourceSignal(
+                dataSourceWeights,
+                signals,
+                "completed",
+                appointmentRepository.findPlaceDataSourceStatsByUserIdAndStatuses(
+                        userId,
+                        List.of(AppointmentStatus.COMPLETED)
+                ),
+                0.25,
+                5.0,
+                false
+        );
+        applyDataSourceSignal(
+                dataSourceWeights,
+                signals,
+                "cancelled",
+                appointmentRepository.findPlaceDataSourceStatsByUserIdAndStatuses(
+                        userId,
+                        List.of(AppointmentStatus.CANCELLED)
+                ),
+                0.35,
+                4.0,
+                true
+        );
+
+        return new UserPreferenceProfile(
+                Map.copyOf(categoryWeights),
+                Map.copyOf(dataSourceWeights),
+                List.copyOf(signals)
+        );
+    }
+
+    private void applyCategorySignal(Map<MissionCategory, Double> weights,
+                                     List<PreferenceSignal> signals,
+                                     String signalType,
+                                     List<Object[]> stats,
+                                     double maxDelta,
+                                     double fullConfidenceCount,
+                                     boolean negative) {
+        long totalCount = sumCounts(stats);
+        if (totalCount == 0) {
+            return;
+        }
+
+        double confidence = Math.min(1.0, totalCount / fullConfidenceCount);
+        for (Object[] row : stats) {
+            if (!(row[0] instanceof MissionCategory category) || !(row[1] instanceof Long count)) {
+                continue;
+            }
+
+            double delta = signedDelta(maxDelta, count, totalCount, confidence, negative);
+            weights.put(category, clampWeight(weights.get(category) + delta));
+            signals.add(new PreferenceSignal(
+                    "MISSION_CATEGORY",
+                    signalType,
+                    category.name(),
+                    count,
+                    totalCount,
+                    round(delta)
+            ));
+        }
+    }
+
+    private void applyDataSourceSignal(Map<DataSource, Double> weights,
+                                       List<PreferenceSignal> signals,
+                                       String signalType,
+                                       List<Object[]> stats,
+                                       double maxDelta,
+                                       double fullConfidenceCount,
+                                       boolean negative) {
+        long totalCount = sumCounts(stats);
+        if (totalCount == 0) {
+            return;
+        }
+
+        double confidence = Math.min(1.0, totalCount / fullConfidenceCount);
+        for (Object[] row : stats) {
+            if (!(row[1] instanceof Long count)) {
+                continue;
+            }
+
+            DataSource dataSource = row[0] instanceof DataSource source ? source : DataSource.MANUAL;
+            double delta = signedDelta(maxDelta, count, totalCount, confidence, negative);
+            weights.put(dataSource, clampWeight(weights.get(dataSource) + delta));
+            signals.add(new PreferenceSignal(
+                    "DATA_SOURCE",
+                    signalType,
+                    dataSource.name(),
+                    count,
+                    totalCount,
+                    round(delta)
+            ));
+        }
+    }
+
+    private double signedDelta(double maxDelta,
+                               long count,
+                               long totalCount,
+                               double confidence,
+                               boolean negative) {
+        double share = (double) count / totalCount;
+        double delta = maxDelta * share * confidence;
+        return negative ? -delta : delta;
+    }
+
+    private long sumCounts(List<Object[]> stats) {
+        return stats.stream()
+                .map(row -> row[1])
+                .filter(Long.class::isInstance)
+                .map(Long.class::cast)
+                .mapToLong(Long::longValue)
+                .sum();
+    }
+
+    private double clampWeight(double value) {
+        return round(Math.max(MIN_WEIGHT, Math.min(MAX_WEIGHT, value)));
+    }
+
+    private double round(double value) {
+        return Math.round(value * 100.0) / 100.0;
+    }
+
+    public record PreferenceSignal(
+            String targetType,
+            String signalType,
+            String key,
+            long count,
+            long totalCount,
+            double delta
+    ) {
+    }
+
+    public record UserPreferenceProfile(
+            Map<MissionCategory, Double> categoryWeights,
+            Map<DataSource, Double> dataSourceWeights,
+            List<PreferenceSignal> signals
+    ) {
+        public double categoryWeight(MissionCategory category) {
+            if (category == null) {
+                return DEFAULT_WEIGHT;
+            }
+            return categoryWeights.getOrDefault(category, DEFAULT_WEIGHT);
+        }
+
+        public double dataSourceWeight(DataSource dataSource) {
+            DataSource resolvedSource = dataSource != null ? dataSource : DataSource.MANUAL;
+            return dataSourceWeights.getOrDefault(resolvedSource, DEFAULT_WEIGHT);
+        }
+
+        public boolean hasSignals() {
+            return !signals.isEmpty();
+        }
+    }
+}

--- a/backend/src/main/java/com/littleescape/api/service/RecommendationSupportService.java
+++ b/backend/src/main/java/com/littleescape/api/service/RecommendationSupportService.java
@@ -1,0 +1,138 @@
+package com.littleescape.api.service;
+
+import com.littleescape.api.domain.type.LocationType;
+import com.littleescape.api.domain.type.MissionCategory;
+import com.littleescape.api.domain.type.TimeOfDay;
+import com.littleescape.api.domain.type.Congestion;
+import com.littleescape.api.service.simulation.EnvironmentContext;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+public class RecommendationSupportService {
+
+    private static final double BASE_LIBRARY_WEIGHT = 0.3;
+
+    public List<TimeOfDay> resolveTimeOfDayOptions(LocalDateTime targetDateTime) {
+        LocalDateTime effectiveDateTime = targetDateTime != null ? targetDateTime : LocalDateTime.now();
+        int hour = effectiveDateTime.getHour();
+        List<TimeOfDay> times = new ArrayList<>();
+
+        if (hour >= 6 && hour < 12) {
+            times.add(TimeOfDay.MORNING);
+        } else if (hour >= 12 && hour < 18) {
+            times.add(TimeOfDay.AFTERNOON);
+        } else {
+            times.add(TimeOfDay.NIGHT);
+        }
+
+        times.add(TimeOfDay.ANY);
+        return times;
+    }
+
+    public List<TimeOfDay> resolveTimeOfDayOptions(EnvironmentContext context) {
+        return resolveTimeOfDayOptions(context != null ? context.getTargetDateTime() : null);
+    }
+
+    public List<LocationType> resolveLocationTypes(boolean outdoorRestricted, boolean indoorPreferred) {
+        List<LocationType> locations = new ArrayList<>();
+
+        if (outdoorRestricted || indoorPreferred) {
+            locations.add(LocationType.INDOOR);
+            locations.add(LocationType.ANY);
+            return locations;
+        }
+
+        locations.add(LocationType.INDOOR);
+        locations.add(LocationType.OUTDOOR);
+        locations.add(LocationType.ANY);
+        return locations;
+    }
+
+    public List<LocationType> resolveLocationTypes(EnvironmentContext context) {
+        if (context == null) {
+            return resolveLocationTypes(false, false);
+        }
+        return resolveLocationTypes(context.isOutdoorRestricted(), context.isIndoorPreferred());
+    }
+
+    public List<MissionCategory> mapMissionToPlaceCategories(MissionCategory missionCategory) {
+        List<MissionCategory> mapping = new ArrayList<>();
+
+        switch (missionCategory) {
+            case ACTIVITY:
+                mapping.add(MissionCategory.ACTIVITY);
+                mapping.add(MissionCategory.CULTURE);
+                break;
+            case CULTURE:
+                mapping.add(MissionCategory.CULTURE);
+                break;
+            case RELAX:
+                mapping.add(MissionCategory.RELAX);
+                mapping.add(MissionCategory.CULTURE);
+                break;
+            case FOOD:
+                mapping.add(MissionCategory.FOOD);
+                mapping.add(MissionCategory.RELAX);
+                break;
+            default:
+                mapping.add(missionCategory);
+                break;
+        }
+
+        return mapping;
+    }
+
+    public double resolveLibrarySourceWeight(EnvironmentContext context) {
+        if (context == null) {
+            return BASE_LIBRARY_WEIGHT;
+        }
+
+        double libraryWeight = BASE_LIBRARY_WEIGHT;
+        if (context.getCongestion() == null) {
+            return libraryWeight;
+        }
+
+        if (context.getCongestion() == Congestion.HIGH && context.isIntrovert()) {
+            return libraryWeight + 0.3;
+        }
+
+        if (context.getCongestion() == Congestion.NORMAL && context.isIntrovert()) {
+            return libraryWeight + 0.15;
+        }
+
+        if (context.getCongestion() == Congestion.LOW && context.isExtrovert()) {
+            return Math.max(0.1, libraryWeight - 0.1);
+        }
+
+        return libraryWeight;
+    }
+
+    public String describeLibrarySourceWeight(EnvironmentContext context) {
+        double libraryWeight = resolveLibrarySourceWeight(context);
+        if (context == null) {
+            return String.format("Library base weight %.2f (no environment context)", libraryWeight);
+        }
+
+        if (context.getCongestion() == null) {
+            return String.format("Library base weight %.2f (no congestion)", libraryWeight);
+        }
+
+        if (context.getCongestion() == Congestion.HIGH && context.isIntrovert()) {
+            return String.format("Library base weight 0.30 -> %.2f (HIGH + I)", libraryWeight);
+        }
+
+        if (context.getCongestion() == Congestion.NORMAL && context.isIntrovert()) {
+            return String.format("Library base weight 0.30 -> %.2f (NORMAL + I)", libraryWeight);
+        }
+
+        if (context.getCongestion() == Congestion.LOW && context.isExtrovert()) {
+            return String.format("Library base weight 0.30 -> %.2f (LOW + E)", libraryWeight);
+        }
+
+        return String.format("Library base weight %.2f (no MBTI/congestion adjustment)", libraryWeight);
+    }
+}

--- a/backend/src/main/java/com/littleescape/api/service/RecommendationTagConflictService.java
+++ b/backend/src/main/java/com/littleescape/api/service/RecommendationTagConflictService.java
@@ -1,0 +1,141 @@
+package com.littleescape.api.service;
+
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+@Service
+public class RecommendationTagConflictService {
+
+    private static final List<TagConflictRule> RULES = List.of(
+            new TagConflictRule(
+                    "NO_ALCOHOL",
+                    "ALCOHOL_ONLY",
+                    "USER_TAG_CONFLICT_NO_ALCOHOL",
+                    "userTag=NO_ALCOHOL,targetTag=ALCOHOL_ONLY"
+            ),
+            new TagConflictRule(
+                    "HATE_WALKING",
+                    "HIGH_ACTIVITY",
+                    "USER_TAG_CONFLICT_HATE_WALKING",
+                    "userTag=HATE_WALKING,targetTag=HIGH_ACTIVITY"
+            ),
+            new TagConflictRule(
+                    "NO_SPORTS",
+                    "SPORTS_REQUIRED",
+                    "USER_TAG_CONFLICT_NO_SPORTS",
+                    "userTag=NO_SPORTS,targetTag=SPORTS_REQUIRED"
+            ),
+            new TagConflictRule(
+                    "INDOOR_ONLY",
+                    "OUTDOOR_REQUIRED",
+                    "USER_TAG_CONFLICT_INDOOR_ONLY",
+                    "userTag=INDOOR_ONLY,targetTag=OUTDOOR_REQUIRED"
+            )
+    );
+
+    private static final Set<String> HARD_CONSTRAINT_TAGS = RULES.stream()
+            .map(TagConflictRule::userTag)
+            .collect(Collectors.toUnmodifiableSet());
+
+    public boolean hasConflict(String userTags, String targetTags) {
+        Set<String> normalizedUserTags = normalizeTags(userTags);
+        Set<String> normalizedTargetTags = normalizeTags(targetTags);
+
+        if (normalizedUserTags.isEmpty() || normalizedTargetTags.isEmpty()) {
+            return false;
+        }
+
+        return RULES.stream().anyMatch(rule ->
+                normalizedUserTags.contains(rule.userTag())
+                        && normalizedTargetTags.contains(rule.targetTag())
+        );
+    }
+
+    public List<String> normalizeUserTags(String userTags) {
+        return List.copyOf(normalizeTags(userTags));
+    }
+
+    public List<String> normalizeHardConstraintTags(String userTags) {
+        return normalizeTags(userTags).stream()
+                .filter(HARD_CONSTRAINT_TAGS::contains)
+                .toList();
+    }
+
+    public <T> TagConflictFilterResult<T> filterConflicts(
+            List<T> candidates,
+            String userTags,
+            Function<T, String> targetTagsExtractor
+    ) {
+        List<String> normalizedUserTags = normalizeHardConstraintTags(userTags);
+        if (normalizedUserTags.isEmpty() || candidates.isEmpty()) {
+            return new TagConflictFilterResult<>(List.copyOf(candidates), List.of(), normalizedUserTags);
+        }
+
+        List<T> current = new ArrayList<>(candidates);
+        List<TagConflictStep> steps = new ArrayList<>();
+
+        for (TagConflictRule rule : RULES) {
+            if (!normalizedUserTags.contains(rule.userTag())) {
+                continue;
+            }
+
+            int before = current.size();
+            current = current.stream()
+                    .filter(candidate -> !normalizeTags(targetTagsExtractor.apply(candidate)).contains(rule.targetTag()))
+                    .collect(Collectors.toList());
+
+            steps.add(new TagConflictStep(
+                    rule.reasonCode(),
+                    before,
+                    current.size(),
+                    rule.detail()
+            ));
+        }
+
+        return new TagConflictFilterResult<>(List.copyOf(current), List.copyOf(steps), normalizedUserTags);
+    }
+
+    private LinkedHashSet<String> normalizeTags(String tags) {
+        LinkedHashSet<String> normalized = new LinkedHashSet<>();
+        if (tags == null || tags.isBlank()) {
+            return normalized;
+        }
+
+        for (String token : tags.split(",")) {
+            String value = token.trim().toUpperCase();
+            if (!value.isEmpty()) {
+                normalized.add(value);
+            }
+        }
+        return normalized;
+    }
+
+    private record TagConflictRule(
+            String userTag,
+            String targetTag,
+            String reasonCode,
+            String detail
+    ) {
+    }
+
+    public record TagConflictStep(
+            String reasonCode,
+            int beforeCount,
+            int afterCount,
+            String detail
+    ) {
+    }
+
+    public record TagConflictFilterResult<T>(
+            List<T> candidates,
+            List<TagConflictStep> steps,
+            List<String> normalizedUserTags
+    ) {
+    }
+}

--- a/backend/src/main/java/com/littleescape/api/service/SimulationService.java
+++ b/backend/src/main/java/com/littleescape/api/service/SimulationService.java
@@ -2,7 +2,13 @@ package com.littleescape.api.service;
 
 import com.littleescape.api.domain.MissionTemplate;
 import com.littleescape.api.domain.Place;
-import com.littleescape.api.domain.type.*;
+import com.littleescape.api.domain.type.AirQuality;
+import com.littleescape.api.domain.type.Congestion;
+import com.littleescape.api.domain.type.DataSource;
+import com.littleescape.api.domain.type.LocationType;
+import com.littleescape.api.domain.type.MissionCategory;
+import com.littleescape.api.domain.type.TimeOfDay;
+import com.littleescape.api.domain.type.Weather;
 import com.littleescape.api.dto.MissionTemplateResponse;
 import com.littleescape.api.dto.simulation.SimulationRequest;
 import com.littleescape.api.dto.simulation.SimulationResponse;
@@ -15,13 +21,16 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
-import java.util.*;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
-/**
- * God Mode Simulation Service
- * 환경 변수를 통제하여 추천 로직을 테스트하는 서비스
- */
 @Service
 @RequiredArgsConstructor
 @Slf4j
@@ -30,18 +39,18 @@ public class SimulationService {
     private final MissionTemplateRepository missionTemplateRepository;
     private final PlaceRepository placeRepository;
     private final ContentFilteringService contentFilteringService;
+    private final RecommendationTagConflictService recommendationTagConflictService;
+    private final RecommendationSupportService recommendationSupportService;
+    private final PlaceScheduleFilterService placeScheduleFilterService;
+    private final PlaceRecommendationScoringService placeRecommendationScoringService;
+    private final RecommendationPreferenceService recommendationPreferenceService;
+    private final MissionRecommendationSelectionService missionRecommendationSelectionService;
 
-    /**
-     * 시뮬레이션 실행 - 환경 변수를 통제하여 추천 결과 생성
-     */
     @Transactional
     public SimulationResponse runSimulation(SimulationRequest request) {
-        log.info("=== God Mode Simulation 시작 ===");
+        log.info("=== God Mode Simulation start ===");
 
-        // 디버그 로그 수집
         List<String> debugLogs = new ArrayList<>();
-
-        // 1. 환경 컨텍스트 생성
         EnvironmentContext context = EnvironmentContext.fromSimulation(
                 request.targetDateTime(),
                 request.latitude(),
@@ -52,498 +61,1050 @@ public class SimulationService {
                 request.airQuality(),
                 request.congestion(),
                 request.userMbti(),
-                null // 시뮬레이션에서는 사용자 태그 미사용
+                request.userTags()
         );
 
-        debugLogs.add(String.format("🕒 시뮬레이션 시간: %s (%s, %d시)",
-                context.getTargetDateTime(), context.getDayOfWeek(), context.getHour()));
-        debugLogs.add(String.format("📍 위치: (%.4f, %.4f), 반경: %dkm",
-                context.getLatitude(), context.getLongitude(), context.getSearchRadius()));
-        debugLogs.add(String.format("☁️ 날씨: %s, 기온: %.1f°C, 미세먼지: %s",
-                context.getWeather(), context.getTemperature(), context.getAirQuality()));
-        debugLogs.add(String.format("👥 혼잡도: %s, MBTI: %s",
-                context.getCongestion(), context.getUserMbti()));
-
-        // 2. 미션 필터링
-        List<MissionTemplate> missionCandidates = filterMissions(context, request.forcedCategory(), debugLogs);
-
-        if (missionCandidates.isEmpty()) {
-            debugLogs.add("❌ 조건에 맞는 미션을 찾을 수 없습니다.");
-            return new SimulationResponse(null, null, debugLogs, 0, 0, 0, 0, List.of(), List.of());
+        debugLogs.add(String.format(
+                "Simulation context: %s (%s, hour=%d)",
+                context.getTargetDateTime(),
+                context.getDayOfWeek(),
+                context.getHour()
+        ));
+        debugLogs.add(String.format(
+                "Location: (%.4f, %.4f), radius=%dkm",
+                context.getLatitude(),
+                context.getLongitude(),
+                context.getSearchRadius()
+        ));
+        debugLogs.add(String.format(
+                "Environment: weather=%s, temperature=%.1fC, airQuality=%s",
+                context.getWeather(),
+                context.getTemperature(),
+                context.getAirQuality()
+        ));
+        debugLogs.add(String.format(
+                "Persona: congestion=%s, mbti=%s",
+                context.getCongestion(),
+                context.getUserMbti()
+        ));
+        if (context.hasUserTags()) {
+            debugLogs.add("User constraints: " + recommendationTagConflictService.normalizeUserTags(context.getUserTags()));
         }
 
-        // 3. 랜덤으로 미션 선택
-        Collections.shuffle(missionCandidates);
-        MissionTemplate selectedMission = missionCandidates.get(0);
+        RecommendationPreferenceService.UserPreferenceProfile preferenceProfile =
+                request.userId() != null ? recommendationPreferenceService.buildProfile(request.userId()) : null;
+        appendPreferenceProfileDebug(debugLogs, request.userId(), preferenceProfile);
 
-        debugLogs.add(String.format("✅ 선택된 미션: %s (카테고리: %s, 난이도: %s)",
-                selectedMission.getTitle(), selectedMission.getCategory(), selectedMission.getDifficultyLevel()));
+        MissionFilterResult missionResult = filterMissions(context, request.forcedCategory(), debugLogs);
+        List<SimulationResponse.StageInfo> stages = new ArrayList<>(missionResult.stages());
 
-        // 4. 장소 필터링 (dev-console: isPlaceRequired 와 무관하게 항상 조회)
+        if (missionResult.candidates().isEmpty()) {
+            debugLogs.add("No mission candidates matched the current simulation conditions.");
+            stages.add(buildFinalSelectionStage(List.of(), null, List.of(), null, false));
+
+            return new SimulationResponse(
+                    null,
+                    null,
+                    debugLogs,
+                    stages,
+                    missionResult.totalCount(),
+                    0,
+                    0,
+                    0,
+                    List.of(),
+                    List.of()
+            );
+        }
+
+        MissionRecommendationSelectionService.MissionSelectionResult missionSelectionResult =
+                missionRecommendationSelectionService.selectMission(missionResult.candidates(), preferenceProfile);
+        List<MissionTemplate> missionCandidates = missionSelectionResult.rankedCandidates().stream()
+                .map(MissionRecommendationSelectionService.MissionCandidateScore::mission)
+                .collect(Collectors.toList());
+        MissionTemplate selectedMission = missionSelectionResult.selected().mission();
+        stages.add(buildMissionSelectionStage(missionSelectionResult, preferenceProfile, request.userId()));
+        debugLogs.add(String.format(
+                "Selected mission: %s (%s, %s, weight=%.2f, point=%.3f/%.3f)",
+                selectedMission.getTitle(),
+                selectedMission.getCategory(),
+                selectedMission.getDifficultyLevel(),
+                missionSelectionResult.selected().categoryWeight(),
+                missionSelectionResult.selectedPoint(),
+                missionSelectionResult.totalWeight()
+        ));
+
+        boolean isPlaceRequired = Boolean.TRUE.equals(selectedMission.getIsPlaceRequired());
+        debugLogs.add(isPlaceRequired
+                ? "Selected mission requires a place. Running place pipeline."
+                : "Selected mission does not require a place. DevConsole still runs the place pipeline for inspection.");
+
+        PlaceFilterResult placeResult = filterPlaces(context, selectedMission.getCategory(), debugLogs);
+        List<Place> placeCandidates = new ArrayList<>(placeResult.candidates());
+        Place selectedPlace = null;
         SimulationResponse.PlaceInfo placeInfo = null;
-        List<Place> placeCandidates = new ArrayList<>();
-        int totalPlaceCandidates = 0;
-        int filteredPlaceCandidates = 0;
-
-        boolean isPlaceRequired = selectedMission.getIsPlaceRequired() != null && selectedMission.getIsPlaceRequired();
-        if (isPlaceRequired) {
-            debugLogs.add("🏠 장소가 필요한 미션 - 장소 필터링 시작");
-        } else {
-            debugLogs.add("🌍 장소 불필요 미션이지만, dev-console에서 전체 장소도 함께 조회합니다");
-        }
-
-        placeCandidates = filterPlaces(context, selectedMission.getCategory(), debugLogs);
-        totalPlaceCandidates = placeCandidates.size();
 
         if (!placeCandidates.isEmpty()) {
-            Collections.shuffle(placeCandidates);
-            Place selectedPlace = placeCandidates.get(0);
-            filteredPlaceCandidates = placeCandidates.size();
-
+            PlaceRecommendationScoringService.PlaceSelectionResult placeSelectionResult =
+                    placeRecommendationScoringService.selectTopPlace(
+                            placeCandidates,
+                            new PlaceRecommendationScoringService.PlaceRankingContext(
+                                    selectedMission.getCategory(),
+                                    context.getUserTags(),
+                                    context.getLatitude(),
+                                    context.getLongitude(),
+                                    context.getSearchRadius(),
+                                    context,
+                                    preferenceProfile
+                            )
+                    );
+            selectedPlace = placeSelectionResult.selected() != null
+                    ? placeSelectionResult.selected().place()
+                    : null;
             placeInfo = SimulationResponse.PlaceInfo.from(selectedPlace);
-
-            debugLogs.add(String.format("✅ 선택된 장소: %s (카테고리: %s)",
-                    selectedPlace.getName(), selectedPlace.getCategory()));
+            debugLogs.add(String.format(
+                    "Selected place: %s (%s, score=%.1f, tieBreak=%s)",
+                    selectedPlace.getName(),
+                    selectedPlace.getCategory(),
+                    placeSelectionResult.selected().totalScore(),
+                    placeSelectionResult.tieBreakApplied()
+            ));
         } else {
-            debugLogs.add("❌ 조건에 맞는 장소를 찾을 수 없습니다.");
+            debugLogs.add(isPlaceRequired
+                    ? "No place candidates survived the pipeline for the selected mission."
+                    : "No place candidates survived the pipeline.");
         }
 
-        // 5. 전체 미션 목록 변환
+        stages.addAll(placeResult.stages());
+        stages.add(buildFinalSelectionStage(
+                missionCandidates,
+                selectedMission,
+                placeCandidates,
+                selectedPlace,
+                isPlaceRequired
+        ));
+
         List<MissionTemplateResponse> allMissions = missionCandidates.stream()
                 .map(MissionTemplateResponse::from)
                 .collect(Collectors.toList());
-
-        // 6. 전체 장소 목록 변환 (허브 + 디테일 통합)
         List<SimulationResponse.PlaceInfo> allPlaces = placeCandidates.stream()
                 .map(SimulationResponse.PlaceInfo::from)
                 .collect(Collectors.toList());
 
-        // 7. 응답 생성
-        MissionTemplateResponse missionResponse = MissionTemplateResponse.from(selectedMission);
-
-        log.info("=== God Mode Simulation 완료 ===");
+        log.info("=== God Mode Simulation complete ===");
         return new SimulationResponse(
-                missionResponse,
+                MissionTemplateResponse.from(selectedMission),
                 placeInfo,
                 debugLogs,
+                stages,
+                missionResult.totalCount(),
                 missionCandidates.size(),
-                missionCandidates.size(),
-                totalPlaceCandidates,
-                filteredPlaceCandidates,
+                placeResult.totalCount(),
+                placeCandidates.size(),
                 allMissions,
                 allPlaces
         );
     }
 
-    /**
-     * 미션 필터링 로직
-     */
-    private List<MissionTemplate> filterMissions(
+    private MissionFilterResult filterMissions(
             EnvironmentContext context,
             MissionCategory forcedCategory,
-            List<String> debugLogs) {
-
-        // 1. 시간대 분석
+            List<String> debugLogs
+    ) {
+        List<SimulationResponse.StageInfo> stages = new ArrayList<>();
+        List<MissionTemplate> allMissions = missionTemplateRepository.findAll();
         List<TimeOfDay> targetTimes = analyzeTimeOfDay(context, debugLogs);
-
-        // 2. 장소 타입 분석 (날씨 기반)
         List<LocationType> targetLocations = analyzeLocation(context, debugLogs);
 
-        // 3. 카테고리 강제 지정 여부
-        if (forcedCategory != null) {
-            debugLogs.add(String.format("🎯 카테고리 강제 지정: %s", forcedCategory));
-        }
+        List<SimulationResponse.ReasonInfo> baseReasons = new ArrayList<>();
+        List<MissionTemplate> scopedMissions = allMissions;
 
-        // 4. 미션 후보 조회
-        List<MissionTemplate> candidates;
         if (forcedCategory != null) {
-            // 카테고리가 강제된 경우, 전체 미션에서 필터링
-            candidates = missionTemplateRepository.findAll().stream()
-                    .filter(m -> m.getCategory() == forcedCategory)
-                    .filter(m -> targetTimes.contains(m.getTimeOfDay()))
-                    .filter(m -> targetLocations.contains(m.getLocationType()))
+            scopedMissions = allMissions.stream()
+                    .filter(mission -> mission.getCategory() == forcedCategory)
                     .collect(Collectors.toList());
-        } else {
-            // 일반 경우
-            candidates = missionTemplateRepository.findAllByTimeOfDayInAndLocationTypeIn(
-                    targetTimes, targetLocations);
+            baseReasons.add(reason(
+                    "FORCED_CATEGORY",
+                    allMissions.size(),
+                    scopedMissions.size(),
+                    "forcedCategory=" + forcedCategory
+            ));
+            debugLogs.add("Forced mission category applied: " + forcedCategory);
         }
 
-        debugLogs.add(String.format("📋 조건에 맞는 미션 후보: %d개", candidates.size()));
+        List<MissionTemplate> timeLocationCandidates = scopedMissions.stream()
+                .filter(mission -> targetTimes.contains(mission.getTimeOfDay()))
+                .filter(mission -> targetLocations.contains(mission.getLocationType()))
+                .collect(Collectors.toList());
 
-        // 5. 시간대별 추가 필터링
-        candidates = applyTimeFilters(candidates, context, debugLogs);
+        baseReasons.add(reason(
+                "TIME_LOCATION_MATCH",
+                scopedMissions.size(),
+                timeLocationCandidates.size(),
+                "times=" + targetTimes + ", locations=" + targetLocations
+        ));
+        debugLogs.add("Mission candidates after time/location filter: " + timeLocationCandidates.size());
 
-        debugLogs.add(String.format("✅ 필터링 후 미션 후보: %d개", candidates.size()));
+        stages.add(stage(
+                "MISSION_TIME_LOCATION_FILTER",
+                "Mission: time/location filter",
+                "MISSION",
+                allMissions.size(),
+                timeLocationCandidates.size(),
+                baseReasons,
+                List.of()
+        ));
 
-        return candidates;
+        FilterOutcome<MissionTemplate> contextFiltered = applyMissionContextFilters(
+                timeLocationCandidates,
+                context,
+                debugLogs
+        );
+
+        stages.add(stage(
+                "MISSION_CONTEXT_FILTER",
+                "Mission: schedule/tag filter",
+                "MISSION",
+                timeLocationCandidates.size(),
+                contextFiltered.candidates().size(),
+                contextFiltered.reasons(),
+                List.of()
+        ));
+
+        return new MissionFilterResult(
+                contextFiltered.candidates(),
+                allMissions.size(),
+                stages
+        );
     }
 
-    /**
-     * 시간대 분석
-     */
     private List<TimeOfDay> analyzeTimeOfDay(EnvironmentContext context, List<String> debugLogs) {
-        int hour = context.getHour();
-        List<TimeOfDay> times = new ArrayList<>();
-
-        if (hour >= 6 && hour < 12) {
-            times.add(TimeOfDay.MORNING);
-            debugLogs.add("⏰ 시간대: 아침 (MORNING)");
-        } else if (hour >= 12 && hour < 18) {
-            times.add(TimeOfDay.AFTERNOON);
-            debugLogs.add("⏰ 시간대: 오후 (AFTERNOON)");
-        } else {
-            times.add(TimeOfDay.NIGHT);
-            debugLogs.add("⏰ 시간대: 밤 (NIGHT)");
-        }
-
-        times.add(TimeOfDay.ANY);
+        List<TimeOfDay> times = recommendationSupportService.resolveTimeOfDayOptions(context);
+        TimeOfDay primaryTime = times.stream()
+                .filter(time -> time != TimeOfDay.ANY)
+                .findFirst()
+                .orElse(TimeOfDay.ANY);
+        debugLogs.add("Time of day resolved to " + primaryTime + ".");
         return times;
     }
 
-    /**
-     * 장소 타입 분석 (날씨 기반)
-     */
     private List<LocationType> analyzeLocation(EnvironmentContext context, List<String> debugLogs) {
-        List<LocationType> locations = new ArrayList<>();
+        List<LocationType> locations = recommendationSupportService.resolveLocationTypes(context);
 
         if (context.isOutdoorRestricted()) {
-            // 야외 활동 제한 (비/눈/극한 기온/최악의 미세먼지)
-            locations.add(LocationType.INDOOR);
-            locations.add(LocationType.ANY);
-            debugLogs.add("🌧️ 야외 활동 제한 - 실내 장소만 추천 (비/눈/극한기온/미세먼지)");
+            debugLogs.add("Outdoor activity restricted. Indoor-only mission scope enabled.");
         } else if (context.isIndoorPreferred()) {
-            // 실내 선호 (미세먼지 나쁨)
-            locations.add(LocationType.INDOOR);
-            locations.add(LocationType.ANY);
-            debugLogs.add("🏠 실내 장소 선호 - 미세먼지 나쁨");
+            debugLogs.add("Indoor preference enabled by weather or air quality.");
         } else {
-            // 모든 장소 가능
-            locations.add(LocationType.INDOOR);
-            locations.add(LocationType.OUTDOOR);
-            locations.add(LocationType.ANY);
-            debugLogs.add("☀️ 모든 장소 타입 가능");
+            debugLogs.add("Indoor and outdoor mission scope enabled.");
         }
 
         return locations;
     }
 
-    /**
-     * 시간대별 추가 필터링
-     */
-    private List<MissionTemplate> applyTimeFilters(
+    private FilterOutcome<MissionTemplate> applyMissionContextFilters(
             List<MissionTemplate> candidates,
             EnvironmentContext context,
-            List<String> debugLogs) {
-
+            List<String> debugLogs
+    ) {
         List<MissionTemplate> filtered = new ArrayList<>(candidates);
+        List<SimulationResponse.ReasonInfo> reasons = new ArrayList<>();
 
-        // 월요일: 도서관 제외 (CULTURE 카테고리 중 도서관 관련)
         if (context.isMonday()) {
-            int beforeSize = filtered.size();
+            int before = filtered.size();
             filtered = filtered.stream()
-                    .filter(m -> !(m.getCategory() == MissionCategory.CULTURE &&
-                            (m.getTitle().contains("도서관") || m.getDescription().contains("도서관"))))
+                    .filter(mission -> !(mission.getCategory() == MissionCategory.CULTURE
+                            && (mission.getTitle().contains("도서관")
+                            || mission.getDescription().contains("도서관"))))
                     .collect(Collectors.toList());
+            int after = filtered.size();
 
-            if (beforeSize > filtered.size()) {
-                debugLogs.add(String.format("📅 월요일 - 도서관 미션 제외 (%d개 제외됨)",
-                        beforeSize - filtered.size()));
+            reasons.add(reason(
+                    "MONDAY_LIBRARY_EXCLUSION",
+                    before,
+                    after,
+                    "Exclude library-style culture missions on Monday"
+            ));
+
+            if (before > after) {
+                debugLogs.add("Monday rule removed " + (before - after) + " mission(s).");
             }
         }
 
-        // 밤 10시 이후: 전시/공연 제외
         if (context.isLateNight()) {
-            int beforeSize = filtered.size();
+            int before = filtered.size();
             filtered = filtered.stream()
-                    .filter(m -> !(m.getCategory() == MissionCategory.CULTURE &&
-                            (m.getTitle().contains("전시") || m.getTitle().contains("공연"))))
+                    .filter(mission -> !(mission.getCategory() == MissionCategory.CULTURE
+                            && (mission.getTitle().contains("전시")
+                            || mission.getTitle().contains("공연"))))
                     .collect(Collectors.toList());
+            int after = filtered.size();
 
-            if (beforeSize > filtered.size()) {
-                debugLogs.add(String.format("🌙 밤 10시 이후 - 전시/공연 미션 제외 (%d개 제외됨)",
-                        beforeSize - filtered.size()));
+            reasons.add(reason(
+                    "LATE_NIGHT_CULTURE_EXCLUSION",
+                    before,
+                    after,
+                    "Exclude exhibition/performance missions after 22:00"
+            ));
+
+            if (before > after) {
+                debugLogs.add("Late-night rule removed " + (before - after) + " mission(s).");
             }
         }
 
-        return filtered;
+        FilterOutcome<MissionTemplate> tagFiltered = applyUserTagConflictFilter(
+                filtered,
+                context.getUserTags(),
+                MissionTemplate::getTags,
+                "Mission",
+                debugLogs
+        );
+        filtered = tagFiltered.candidates();
+        reasons.addAll(tagFiltered.reasons());
+
+        if (reasons.isEmpty()) {
+            reasons.add(reason(
+                    "NO_MISSION_CONTEXT_FILTER",
+                    filtered.size(),
+                    filtered.size(),
+                    "No additional mission context rules applied"
+            ));
+        }
+
+        debugLogs.add("Mission candidates after context filter: " + filtered.size());
+        return new FilterOutcome<>(filtered, reasons);
     }
 
-    /**
-     * 장소 필터링 로직
-     */
-    private List<Place> filterPlaces(
+    private PlaceFilterResult filterPlaces(
             EnvironmentContext context,
             MissionCategory missionCategory,
-            List<String> debugLogs) {
-
-        // 1. 카테고리 매핑
+            List<String> debugLogs
+    ) {
+        List<SimulationResponse.StageInfo> stages = new ArrayList<>();
+        List<Place> activePlaces = placeRepository.findByIsActiveTrue();
         List<MissionCategory> targetCategories = getCategoryMapping(missionCategory);
-        debugLogs.add(String.format("🗂️ 매칭 카테고리: %s", targetCategories));
 
-        // 2. 카테고리별 장소 검색
-        List<Place> allPlaces = new ArrayList<>();
+        debugLogs.add("Mapped place categories: " + targetCategories);
+
+        List<Place> categoryScopedPlaces = loadActivePlacesForCategories(targetCategories);
+        stages.add(stage(
+                "PLACE_CATEGORY_MAPPING",
+                "Place: category mapping",
+                "PLACE",
+                activePlaces.size(),
+                categoryScopedPlaces.size(),
+                List.of(reason(
+                        "CATEGORY_MAPPING",
+                        activePlaces.size(),
+                        categoryScopedPlaces.size(),
+                        "mappedCategories=" + targetCategories
+                )),
+                List.of()
+        ));
+
+        int distanceBaseCount = categoryScopedPlaces.size();
+        List<SimulationResponse.ReasonInfo> distanceReasons = new ArrayList<>();
+        List<Place> distanceCandidates;
+
+        if (categoryScopedPlaces.isEmpty()) {
+            distanceBaseCount = activePlaces.size();
+            distanceReasons.add(reason(
+                    "CATEGORY_FALLBACK_ALL_ACTIVE",
+                    0,
+                    activePlaces.size(),
+                    "No active places found in mapped categories"
+            ));
+            debugLogs.add("Category mapping returned 0 active places. Falling back to all active places.");
+            distanceCandidates = placeRepository.findAllWithDistanceAndRadius(
+                    context.getLatitude(),
+                    context.getLongitude(),
+                    context.getSearchRadius()
+            );
+        } else {
+            distanceCandidates = queryPlacesByCategoriesWithinRadius(targetCategories, context);
+        }
+
+        distanceCandidates = deduplicatePlaces(distanceCandidates);
+        distanceReasons.add(reason(
+                "DISTANCE_RADIUS_FILTER",
+                distanceBaseCount,
+                distanceCandidates.size(),
+                "radiusKm=" + context.getSearchRadius()
+        ));
+        debugLogs.add("Place candidates after distance filter: " + distanceCandidates.size());
+
+        stages.add(stage(
+                "PLACE_DISTANCE_FILTER",
+                "Place: distance filter",
+                "PLACE",
+                distanceBaseCount,
+                distanceCandidates.size(),
+                distanceReasons,
+                List.of()
+        ));
+
+        FilterOutcome<Place> keywordFiltered = applyKeywordFilter(distanceCandidates, debugLogs);
+        stages.add(stage(
+                "PLACE_KEYWORD_FILTER",
+                "Place: content keyword filter",
+                "PLACE",
+                distanceCandidates.size(),
+                keywordFiltered.candidates().size(),
+                keywordFiltered.reasons(),
+                List.of()
+        ));
+
+        FilterOutcome<Place> scheduleFiltered = applyPerformanceFilter(
+                keywordFiltered.candidates(),
+                context.getTargetDateTime(),
+                LocalDate.now(),
+                debugLogs
+        );
+        stages.add(stage(
+                "PLACE_SCHEDULE_FILTER",
+                "Place: performance/schedule filter",
+                "PLACE",
+                keywordFiltered.candidates().size(),
+                scheduleFiltered.candidates().size(),
+                scheduleFiltered.reasons(),
+                List.of()
+        ));
+
+        FilterOutcome<Place> personalized = applyPlacePersonalization(
+                scheduleFiltered.candidates(),
+                context,
+                debugLogs
+        );
+        stages.add(stage(
+                "PLACE_PERSONALIZATION_FILTER",
+                "Place: tag/personalization filter",
+                "PLACE",
+                scheduleFiltered.candidates().size(),
+                personalized.candidates().size(),
+                personalized.reasons(),
+                List.of()
+        ));
+
+        return new PlaceFilterResult(
+                personalized.candidates(),
+                activePlaces.size(),
+                stages
+        );
+    }
+
+    private List<Place> loadActivePlacesForCategories(List<MissionCategory> targetCategories) {
+        LinkedHashMap<Long, Place> deduped = new LinkedHashMap<>();
         for (MissionCategory category : targetCategories) {
-            List<Place> places = placeRepository.findByCategoryWithDistance(
+            for (Place place : placeRepository.findByCategoryAndIsActiveTrue(category)) {
+                deduped.putIfAbsent(place.getId(), place);
+            }
+        }
+        return new ArrayList<>(deduped.values());
+    }
+
+    private List<Place> queryPlacesByCategoriesWithinRadius(
+            List<MissionCategory> targetCategories,
+            EnvironmentContext context
+    ) {
+        List<Place> places = new ArrayList<>();
+        for (MissionCategory category : targetCategories) {
+            places.addAll(placeRepository.findByCategoryWithDistanceAndRadius(
                     category,
                     context.getLatitude(),
-                    context.getLongitude()
-            );
-            allPlaces.addAll(places);
+                    context.getLongitude(),
+                    context.getSearchRadius()
+            ));
         }
+        return places;
+    }
 
-        debugLogs.add(String.format("📍 반경 %dkm 내 장소: %d개",
-                context.getSearchRadius(), allPlaces.size()));
-
-        // 3. Fallback - 카테고리 무관 검색
-        if (allPlaces.isEmpty()) {
-            debugLogs.add("⚠️ 카테고리 매칭 장소 없음 - 전체 장소에서 검색");
-            allPlaces = placeRepository.findAllWithDistance(
-                    context.getLatitude(),
-                    context.getLongitude()
-            );
-            debugLogs.add(String.format("📍 Fallback - 전체 장소: %d개", allPlaces.size()));
-        }
-
-        // 4. ContentFilteringService를 사용한 키워드 필터링
-        int beforeFilterSize = allPlaces.size();
-        allPlaces = allPlaces.stream()
-                .filter(p -> !contentFilteringService.shouldExclude(
-                        p.getName(), p.getAddress(), p.getTags()))
+    private FilterOutcome<Place> applyKeywordFilter(List<Place> candidates, List<String> debugLogs) {
+        int before = candidates.size();
+        List<Place> filtered = candidates.stream()
+                .filter(place -> !contentFilteringService.shouldExclude(
+                        place.getName(),
+                        place.getAddress(),
+                        place.getTags()
+                ))
                 .collect(Collectors.toList());
-        int excludedByKeyword = beforeFilterSize - allPlaces.size();
-        if (excludedByKeyword > 0) {
-            debugLogs.add(String.format("🚫 키워드 필터: %d개 → %d개 (제외 %d개)",
-                    beforeFilterSize, allPlaces.size(), excludedByKeyword));
+
+        int after = filtered.size();
+        if (before > after) {
+            debugLogs.add("Keyword filter removed " + (before - after) + " place(s).");
         }
 
-        // 5. 공연/행사 기간 필터링 + 종료 공연 즉시 비활성화
-        LocalDate simulationDate = context.getTargetDateTime().toLocalDate();
-        LocalDate today = LocalDate.now();
-        allPlaces = applyPerformanceFilter(allPlaces, simulationDate, today, debugLogs);
+        return new FilterOutcome<>(
+                filtered,
+                List.of(reason(
+                        "CONTENT_KEYWORD_FILTER",
+                        before,
+                        after,
+                        "Application-level keyword exclusion"
+                ))
+        );
+    }
 
-        // 6. 맑은 날 + 미세먼지 좋음 → 도서관 전체 배제 (야외 활동 유도)
+    private FilterOutcome<Place> applyPlacePersonalization(
+            List<Place> places,
+            EnvironmentContext context,
+            List<String> debugLogs
+    ) {
+        List<SimulationResponse.ReasonInfo> reasons = new ArrayList<>();
+        List<Place> current = new ArrayList<>(places);
+
+        FilterOutcome<Place> tagFiltered = applyUserTagConflictFilter(
+                current,
+                context.getUserTags(),
+                Place::getTags,
+                "Place",
+                debugLogs
+        );
+        current = tagFiltered.candidates();
+        reasons.addAll(tagFiltered.reasons());
+
         if (context.getWeather() == Weather.SUNNY && context.getAirQuality() == AirQuality.GOOD) {
-            int beforeSize = allPlaces.size();
-            allPlaces = allPlaces.stream()
-                    .filter(p -> p.getDataSource() != DataSource.LIBRARY)
+            int before = current.size();
+            current = current.stream()
+                    .filter(place -> place.getDataSource() != DataSource.LIBRARY)
                     .collect(Collectors.toList());
-            int excluded = beforeSize - allPlaces.size();
-            if (excluded > 0) {
-                debugLogs.add(String.format("📚 맑음+미세먼지좋음 → 도서관 %d개 배제 (%d개 → %d개)",
-                        excluded, beforeSize, allPlaces.size()));
+            int after = current.size();
+
+            reasons.add(reason(
+                    "EXCLUDE_LIBRARY_ON_GOOD_WEATHER",
+                    before,
+                    after,
+                    "weather=SUNNY and airQuality=GOOD"
+            ));
+
+            if (before > after) {
+                debugLogs.add("Sunny/good-air preference removed " + (before - after) + " library place(s).");
             }
         }
 
-        // 7. 혼잡도 기반 필터링 (조용한 장소 선호)
         if (context.prefersQuietPlace()) {
-            int beforeSize = allPlaces.size();
-            List<Place> quietPlaces = allPlaces.stream()
-                    .filter(p -> p.getTags() != null && p.getTags().contains("QUIET"))
+            int before = current.size();
+            List<Place> quietPlaces = current.stream()
+                    .filter(place -> place.getTags() != null && place.getTags().contains("QUIET"))
                     .collect(Collectors.toList());
 
             if (!quietPlaces.isEmpty()) {
-                allPlaces = quietPlaces;
-                debugLogs.add(String.format("🤫 혼잡도 높음 - 조용한 장소 우선 (%d개 → %d개)",
-                        beforeSize, allPlaces.size()));
+                current = quietPlaces;
+                reasons.add(reason(
+                        "PREFER_QUIET_TAG",
+                        before,
+                        current.size(),
+                        "congestion=HIGH prefers QUIET-tagged places"
+                ));
+                debugLogs.add("Quiet-place preference narrowed candidates to " + current.size() + " place(s).");
+            } else {
+                reasons.add(reason(
+                        "PREFER_QUIET_TAG_NO_MATCH",
+                        before,
+                        before,
+                        "congestion=HIGH but no QUIET-tagged places were available"
+                ));
             }
         }
 
-        // 8. DataSource별 가중치 기반 선택 (도서관 추천 빈도 억제)
-        allPlaces = applyDataSourceWeighting(allPlaces, context, debugLogs);
+        FilterOutcome<Place> weighted = applyDataSourceWeighting(current, context, debugLogs);
+        current = weighted.candidates();
+        reasons.addAll(weighted.reasons());
 
-        return allPlaces;
+        if (reasons.isEmpty()) {
+            reasons.add(reason(
+                    "NO_PERSONALIZATION_CHANGE",
+                    places.size(),
+                    places.size(),
+                    "No personalization rules changed the place set"
+            ));
+        }
+
+        return new FilterOutcome<>(current, reasons);
     }
 
-    /**
-     * DataSource별 가중치 기반 장소 리밸런싱
-     *
-     * 도서관(LIBRARY)은 수적 우위(서울 200+개)로 인해 과다 추천되는 문제를 해결
-     * - 기본 가중치: 도서관 0.3 (30%), 공원 0.8 (80%), 기타 1.0 (100%)
-     * - 혼잡도 HIGH + MBTI I성향 → 도서관 가중치 보너스 (+0.3)
-     * - 혼잡도 LOW + MBTI E성향 → 도서관 가중치 추가 감소 (-0.1)
-     *
-     * 가중치를 "선택 확률"로 변환하여 가중치가 높은 장소가 리스트 앞쪽에 오도록 정렬 후
-     * 확률 기반으로 장소를 선별합니다.
-     */
-    private List<Place> applyDataSourceWeighting(
+    private <T> FilterOutcome<T> applyUserTagConflictFilter(
+            List<T> candidates,
+            String userTags,
+            Function<T, String> targetTagsExtractor,
+            String scope,
+            List<String> debugLogs
+    ) {
+        RecommendationTagConflictService.TagConflictFilterResult<T> result =
+                recommendationTagConflictService.filterConflicts(candidates, userTags, targetTagsExtractor);
+
+        if (result.normalizedUserTags().isEmpty()) {
+            return new FilterOutcome<>(candidates, List.of());
+        }
+
+        debugLogs.add(scope + " constraints applied: " + result.normalizedUserTags());
+
+        if (result.steps().isEmpty()) {
+            return new FilterOutcome<>(
+                    candidates,
+                    List.of(reason(
+                            "USER_TAG_CONFLICT_FILTER_SKIPPED",
+                            candidates.size(),
+                            candidates.size(),
+                            "userTags=" + result.normalizedUserTags() + ", no supported conflict rule matched"
+                    ))
+            );
+        }
+
+        int removedCount = candidates.size() - result.candidates().size();
+        if (removedCount > 0) {
+            debugLogs.add(scope + " tag conflict filter removed " + removedCount + " candidate(s).");
+        }
+
+        List<SimulationResponse.ReasonInfo> reasons = result.steps().stream()
+                .map(step -> reason(
+                        step.reasonCode(),
+                        step.beforeCount(),
+                        step.afterCount(),
+                        step.detail()
+                ))
+                .collect(Collectors.toList());
+
+        return new FilterOutcome<>(result.candidates(), reasons);
+    }
+
+    private FilterOutcome<Place> applyDataSourceWeighting(
             List<Place> places,
             EnvironmentContext context,
-            List<String> debugLogs) {
+            List<String> debugLogs
+    ) {
+        if (places.isEmpty()) {
+            return new FilterOutcome<>(
+                    places,
+                    List.of(reason(
+                            "DATASOURCE_WEIGHTING_SKIPPED",
+                            0,
+                            0,
+                            "No place candidates available for weighting"
+                    ))
+            );
+        }
 
-        if (places.isEmpty()) return places;
-
-        // 1. DataSource별 기본 가중치 설정
         Map<DataSource, Double> weights = new HashMap<>();
-        weights.put(DataSource.LIBRARY, 0.3);         // 도서관: 기본 30%
-        weights.put(DataSource.SEOUL_PARK, 0.8);       // 공원: 기본 80%
-        weights.put(DataSource.KOPIS, 1.0);            // 공연: 100%
-        weights.put(DataSource.SEOUL_CULTURE, 1.0);    // 문화행사: 100%
-        weights.put(DataSource.SEOUL_RESERVATION, 1.0);// 공공예약: 100%
-        weights.put(DataSource.SEOUL_RESTAURANT, 1.0); // 음식점: 100%
-        weights.put(DataSource.MANUAL, 1.0);           // 수동: 100%
+        weights.put(DataSource.LIBRARY, 0.3);
+        weights.put(DataSource.SEOUL_PARK, 0.8);
+        weights.put(DataSource.KOPIS, 1.0);
+        weights.put(DataSource.SEOUL_CULTURE, 1.0);
+        weights.put(DataSource.SEOUL_RESERVATION, 1.0);
+        weights.put(DataSource.SEOUL_RESTAURANT, 1.0);
+        weights.put(DataSource.MANUAL, 1.0);
 
-        // 2. 혼잡도 + MBTI(I/E) 기반 도서관 가중치 조정
-        double libraryWeight = weights.get(DataSource.LIBRARY);
-        String mbti = context.getUserMbti();
-        boolean isIntrovert = mbti != null && mbti.toUpperCase().startsWith("I");
-        boolean isExtrovert = mbti != null && mbti.toUpperCase().startsWith("E");
-        Congestion congestion = context.getCongestion();
-
-        StringBuilder weightLog = new StringBuilder();
-        weightLog.append(String.format("📊 도서관 기본 가중치: %.1f", libraryWeight));
-
-        // 혼잡도 HIGH + I성향 → 조용한 곳 선호 → 도서관 가중치 보너스
-        if (congestion == Congestion.HIGH && isIntrovert) {
-            libraryWeight += 0.3;
-            weightLog.append(String.format(" → +0.3 (혼잡도 HIGH + I성향) = %.1f", libraryWeight));
-        }
-        // 혼잡도 MEDIUM + I성향 → 약간의 보너스
-        else if (congestion == Congestion.MEDIUM && isIntrovert) {
-            libraryWeight += 0.15;
-            weightLog.append(String.format(" → +0.15 (혼잡도 MEDIUM + I성향) = %.1f", libraryWeight));
-        }
-        // 혼잡도 LOW + E성향 → 활동적인 장소 선호 → 도서관 추가 감소
-        else if (congestion == Congestion.LOW && isExtrovert) {
-            libraryWeight -= 0.1;
-            libraryWeight = Math.max(0.1, libraryWeight); // 최소 10%
-            weightLog.append(String.format(" → -0.1 (혼잡도 LOW + E성향) = %.1f", libraryWeight));
-        }
-
+        double libraryWeight = recommendationSupportService.resolveLibrarySourceWeight(context);
         weights.put(DataSource.LIBRARY, libraryWeight);
-        debugLogs.add(weightLog.toString());
+        debugLogs.add(recommendationSupportService.describeLibrarySourceWeight(context));
 
-        // 3. DataSource별 장소 그룹핑
         Map<DataSource, List<Place>> groupedBySource = places.stream()
                 .collect(Collectors.groupingBy(
-                        p -> p.getDataSource() != null ? p.getDataSource() : DataSource.MANUAL));
+                        place -> place.getDataSource() != null ? place.getDataSource() : DataSource.MANUAL
+                ));
 
-        // 4. 가중치 기반 리밸런싱: 각 그룹에서 가중치 비율만큼 장소 선별
         List<Place> rebalanced = new ArrayList<>();
-        int totalSize = places.size();
-
         for (Map.Entry<DataSource, List<Place>> entry : groupedBySource.entrySet()) {
             DataSource source = entry.getKey();
             List<Place> sourcePlaces = new ArrayList<>(entry.getValue());
             double weight = weights.getOrDefault(source, 1.0);
-
-            // 가중치 적용된 최대 개수 = 원본 개수 * 가중치 (최소 1개)
             int maxCount = Math.max(1, (int) Math.round(sourcePlaces.size() * weight));
 
-            // 셔플 후 가중치만큼만 선별
             Collections.shuffle(sourcePlaces);
             List<Place> selected = sourcePlaces.subList(0, Math.min(maxCount, sourcePlaces.size()));
             rebalanced.addAll(selected);
 
             if (selected.size() < sourcePlaces.size()) {
-                debugLogs.add(String.format("  ⚖️ %s: %d개 → %d개 (가중치 %.1f)",
-                        source, sourcePlaces.size(), selected.size(), weight));
+                debugLogs.add(String.format(
+                        "Datasource weighting: %s %d -> %d (weight %.1f)",
+                        source,
+                        sourcePlaces.size(),
+                        selected.size(),
+                        weight
+                ));
             }
         }
 
-        if (rebalanced.size() != places.size()) {
-            debugLogs.add(String.format("📊 가중치 리밸런싱: %d개 → %d개", places.size(), rebalanced.size()));
-        }
-
-        // 최종 셔플
         Collections.shuffle(rebalanced);
-        return rebalanced;
+        if (rebalanced.size() != places.size()) {
+            debugLogs.add(String.format(
+                    "Datasource weighting changed place count: %d -> %d",
+                    places.size(),
+                    rebalanced.size()
+            ));
+        }
+
+        return new FilterOutcome<>(
+                rebalanced,
+                List.of(reason(
+                        "DATASOURCE_WEIGHTING",
+                        places.size(),
+                        rebalanced.size(),
+                        String.format("libraryWeight=%.2f", libraryWeight)
+                ))
+        );
     }
 
-    /**
-     * 공연/행사 기간 필터링
-     * - performanceDetail이 있는 장소: 시뮬레이션 날짜가 공연 기간(startDate~endDate) 내인 것만 통과
-     * - endDate < 오늘: 공연이 이미 종료 → isActive=false로 즉시 비활성화
-     * - performanceDetail이 없는 장소(음식점, 카페 등): 필터 없이 통과
-     */
-    private List<Place> applyPerformanceFilter(
+    private FilterOutcome<Place> applyPerformanceFilter(
             List<Place> places,
-            LocalDate simulationDate,
+            LocalDateTime simulationDateTime,
             LocalDate today,
-            List<String> debugLogs) {
+            List<String> debugLogs
+    ) {
+        PlaceScheduleFilterService.PlaceScheduleFilterResult scheduleResult =
+                placeScheduleFilterService.filterPlacesBySchedule(places, simulationDateTime, today);
 
-        int beforeSize = places.size();
-        int deactivatedCount = 0;
-        int expiredFilteredCount = 0;
-        int notYetStartedCount = 0;
+        int currentCount = scheduleResult.beforeCount();
+        List<SimulationResponse.ReasonInfo> reasons = new ArrayList<>();
 
-        List<Place> filtered = new ArrayList<>();
-
-        for (Place place : places) {
-            // 공연 detail이 없는 장소 (음식점, 카페, 공원 등) → 그대로 통과
-            if (place.getPerformanceDetail() == null) {
-                filtered.add(place);
-                continue;
-            }
-
-            LocalDate startDate = place.getPerformanceDetail().getStartDate();
-            LocalDate endDate = place.getPerformanceDetail().getEndDate();
-
-            // endDate가 오늘 이전 → 공연 완전 종료 → 즉시 비활성화
-            if (endDate != null && endDate.isBefore(today)) {
-                place.deactivate();
-                deactivatedCount++;
-                debugLogs.add(String.format("🚫 [비활성화] %s - 공연종료(%s), isActive=false 처리",
-                        place.getName(), endDate));
-                continue; // 필터에서 제외
-            }
-
-            // 시뮬레이션 날짜 기준 공연 기간 체크
-            boolean afterStart = (startDate == null || !simulationDate.isBefore(startDate));
-            boolean beforeEnd = (endDate == null || !simulationDate.isAfter(endDate));
-
-            if (afterStart && beforeEnd) {
-                // 시뮬레이션 날짜에 공연중 → 통과
-                filtered.add(place);
-            } else if (!afterStart) {
-                // 아직 시작 전
-                notYetStartedCount++;
-            } else {
-                // 시뮬레이션 날짜 기준 종료 (실제 오늘과 별개)
-                expiredFilteredCount++;
-            }
+        if (scheduleResult.deactivatedCount() > 0) {
+            reasons.add(reason(
+                    "DEACTIVATE_EXPIRED_PERFORMANCE",
+                    currentCount,
+                    currentCount - scheduleResult.deactivatedCount(),
+                    "expiredBeforeToday=" + scheduleResult.deactivatedCount()
+            ));
+            currentCount -= scheduleResult.deactivatedCount();
         }
 
-        int totalExcluded = beforeSize - filtered.size();
-        if (totalExcluded > 0) {
-            debugLogs.add(String.format("🎭 공연 기간 필터: %d개 → %d개 (제외 %d개: 비활성화 %d, 기간외 %d, 미시작 %d)",
-                    beforeSize, filtered.size(), totalExcluded,
-                    deactivatedCount, expiredFilteredCount, notYetStartedCount));
-        }
-        if (deactivatedCount > 0) {
-            debugLogs.add(String.format("⚡ 종료 공연 %d건 즉시 비활성화 완료 (isActive=false)", deactivatedCount));
+        if (scheduleResult.notStartedCount() > 0) {
+            reasons.add(reason(
+                    "EXCLUDE_NOT_YET_STARTED",
+                    currentCount,
+                    currentCount - scheduleResult.notStartedCount(),
+                    "startDate after targetDateTime: " + scheduleResult.notStartedCount()
+            ));
+            currentCount -= scheduleResult.notStartedCount();
         }
 
-        return filtered;
+        if (scheduleResult.expiredCount() > 0) {
+            reasons.add(reason(
+                    "EXCLUDE_OUTSIDE_SIMULATION_DATE",
+                    currentCount,
+                    currentCount - scheduleResult.expiredCount(),
+                    "endDate before targetDateTime: " + scheduleResult.expiredCount()
+            ));
+            currentCount -= scheduleResult.expiredCount();
+        }
+
+        if (scheduleResult.closedDayCount() > 0) {
+            reasons.add(reason(
+                    "EXCLUDE_CLOSED_DAY",
+                    currentCount,
+                    currentCount - scheduleResult.closedDayCount(),
+                    "closedDays matched targetDateTime: " + scheduleResult.closedDayCount()
+            ));
+            currentCount -= scheduleResult.closedDayCount();
+        }
+
+        if (scheduleResult.outsideOperatingHoursCount() > 0) {
+            reasons.add(reason(
+                    "EXCLUDE_OUTSIDE_OPERATING_HOURS",
+                    currentCount,
+                    currentCount - scheduleResult.outsideOperatingHoursCount(),
+                    "operatingTime excluded targetDateTime: " + scheduleResult.outsideOperatingHoursCount()
+            ));
+            currentCount -= scheduleResult.outsideOperatingHoursCount();
+        }
+
+        if (scheduleResult.unavailableOperationInfoCount() > 0) {
+            reasons.add(reason(
+                    "EXCLUDE_CLEARLY_UNAVAILABLE_OPERATION_INFO",
+                    currentCount,
+                    currentCount - scheduleResult.unavailableOperationInfoCount(),
+                    "explicit unavailable operation info: " + scheduleResult.unavailableOperationInfoCount()
+            ));
+            currentCount -= scheduleResult.unavailableOperationInfoCount();
+        }
+
+        if (scheduleResult.unknownOperationalInfoCount() > 0) {
+            reasons.add(reason(
+                    "OPERATIONAL_INFO_FALLBACK",
+                    currentCount,
+                    currentCount,
+                    "unparsed operation info allowed: " + scheduleResult.unknownOperationalInfoCount()
+            ));
+        }
+
+        if (reasons.isEmpty()) {
+            reasons.add(reason(
+                    "PERFORMANCE_SCHEDULE_PASS",
+                    scheduleResult.beforeCount(),
+                    scheduleResult.beforeCount(),
+                    "No schedule or operational exclusions applied"
+            ));
+        } else {
+            debugLogs.add(String.format(
+                    "Performance/operation filter result: %d -> %d (deactivated=%d, notStarted=%d, outsideDate=%d, closedDay=%d, outsideHours=%d, unavailableStatus=%d, unknownOperationalInfo=%d)",
+                    scheduleResult.beforeCount(),
+                    scheduleResult.afterCount(),
+                    scheduleResult.deactivatedCount(),
+                    scheduleResult.notStartedCount(),
+                    scheduleResult.expiredCount(),
+                    scheduleResult.closedDayCount(),
+                    scheduleResult.outsideOperatingHoursCount(),
+                    scheduleResult.unavailableOperationInfoCount(),
+                    scheduleResult.unknownOperationalInfoCount()
+            ));
+            scheduleResult.exclusionDetails().stream()
+                    .limit(3)
+                    .forEach(detail -> debugLogs.add(String.format(
+                            "Operational exclusion: %s (%s) - %s",
+                            detail.placeName(),
+                            detail.reasonCode(),
+                            detail.detail()
+                    )));
+        }
+
+        return new FilterOutcome<>(scheduleResult.filteredPlaces(), reasons);
     }
 
-    /**
-     * 카테고리 매핑 (AppointmentService와 동일한 로직)
-     */
-    private List<MissionCategory> getCategoryMapping(MissionCategory missionCategory) {
-        List<MissionCategory> mapping = new ArrayList<>();
+    private List<Place> deduplicatePlaces(List<Place> places) {
+        LinkedHashMap<Long, Place> deduped = new LinkedHashMap<>();
+        for (Place place : places) {
+            deduped.putIfAbsent(place.getId(), place);
+        }
+        return new ArrayList<>(deduped.values());
+    }
 
-        switch (missionCategory) {
-            case ACTIVITY:
-                mapping.add(MissionCategory.ACTIVITY);
-                mapping.add(MissionCategory.CULTURE);
-                break;
-            case CULTURE:
-                mapping.add(MissionCategory.CULTURE);
-                break;
-            case RELAX:
-                mapping.add(MissionCategory.RELAX);
-                mapping.add(MissionCategory.CULTURE);
-                break;
-            case FOOD:
-                mapping.add(MissionCategory.FOOD);
-                mapping.add(MissionCategory.RELAX);
-                break;
-            default:
-                mapping.add(missionCategory);
-                break;
+    private SimulationResponse.StageInfo buildFinalSelectionStage(
+            List<MissionTemplate> missionCandidates,
+            MissionTemplate selectedMission,
+            List<Place> placeCandidates,
+            Place selectedPlace,
+            boolean isPlaceRequired
+    ) {
+        List<SimulationResponse.ReasonInfo> reasons = new ArrayList<>();
+        List<SimulationResponse.SelectionInfo> selections = new ArrayList<>();
+
+        reasons.add(reason(
+                selectedMission != null ? "SELECT_MISSION" : "NO_MISSION_SELECTED",
+                missionCandidates.size(),
+                selectedMission != null ? 1 : 0,
+                selectedMission != null ? selectedMission.getTitle() : "No mission selected"
+        ));
+
+        if (selectedMission != null) {
+            selections.add(selection(
+                    "MISSION",
+                    selectedMission.getId(),
+                    selectedMission.getTitle(),
+                    selectedMission.getCategory().name(),
+                    "finalSelected=true"
+            ));
         }
 
-        return mapping;
+        if (isPlaceRequired) {
+            reasons.add(reason(
+                    selectedPlace != null ? "SELECT_PLACE" : "PLACE_REQUIRED_NO_MATCH",
+                    placeCandidates.size(),
+                    selectedPlace != null ? 1 : 0,
+                    selectedPlace != null ? selectedPlace.getName() : "Mission required a place but none survived"
+            ));
+        } else {
+            reasons.add(reason(
+                    selectedPlace != null ? "SELECT_OPTIONAL_PLACE" : "PLACE_OPTIONAL_SKIPPED",
+                    placeCandidates.size(),
+                    selectedPlace != null ? 1 : 0,
+                    "Selected mission does not require a place"
+            ));
+        }
+
+        if (selectedPlace != null) {
+            selections.add(selection(
+                    "PLACE",
+                    selectedPlace.getId(),
+                    selectedPlace.getName(),
+                    selectedPlace.getCategory().name(),
+                    "finalSelected=true"
+            ));
+        }
+
+        return stage(
+                "FINAL_SELECTION",
+                "Final selection",
+                "RESULT",
+                missionCandidates.size() + placeCandidates.size(),
+                selections.size(),
+                reasons,
+                selections
+        );
+    }
+
+    private SimulationResponse.StageInfo stage(
+            String code,
+            String label,
+            String targetType,
+            int beforeCount,
+            int afterCount,
+            List<SimulationResponse.ReasonInfo> reasons,
+            List<SimulationResponse.SelectionInfo> selections
+    ) {
+        return new SimulationResponse.StageInfo(
+                code,
+                label,
+                targetType,
+                beforeCount,
+                afterCount,
+                List.copyOf(reasons),
+                List.copyOf(selections)
+        );
+    }
+
+    private SimulationResponse.ReasonInfo reason(
+            String code,
+            int beforeCount,
+            int afterCount,
+            String detail
+    ) {
+        return new SimulationResponse.ReasonInfo(code, beforeCount, afterCount, detail);
+    }
+
+    private SimulationResponse.SelectionInfo selection(
+            String type,
+            Long id,
+            String name,
+            String category,
+            String detail
+    ) {
+        return new SimulationResponse.SelectionInfo(type, id, name, category, detail);
+    }
+
+    private void appendPreferenceProfileDebug(
+            List<String> debugLogs,
+            Long userId,
+            RecommendationPreferenceService.UserPreferenceProfile preferenceProfile
+    ) {
+        if (userId == null) {
+            debugLogs.add("Preference profile: default mission weights (no userId supplied).");
+            return;
+        }
+
+        if (preferenceProfile == null || !preferenceProfile.hasSignals()) {
+            debugLogs.add("Preference profile: userId=" + userId + " has no saved/liked/completed/cancelled signals.");
+            return;
+        }
+
+        debugLogs.add(String.format(
+                "Preference profile: userId=%d, signals=%d",
+                userId,
+                preferenceProfile.signals().size()
+        ));
+        preferenceProfile.signals().stream()
+                .limit(5)
+                .forEach(signal -> debugLogs.add(String.format(
+                        "Preference signal: %s/%s %s delta=%.2f (%d/%d)",
+                        signal.targetType(),
+                        signal.signalType(),
+                        signal.key(),
+                        signal.delta(),
+                        signal.count(),
+                        signal.totalCount()
+                )));
+    }
+
+    private SimulationResponse.StageInfo buildMissionSelectionStage(
+            MissionRecommendationSelectionService.MissionSelectionResult selectionResult,
+            RecommendationPreferenceService.UserPreferenceProfile preferenceProfile,
+            Long userId
+    ) {
+        int candidateCount = selectionResult.rankedCandidates().size();
+        List<SimulationResponse.ReasonInfo> reasons = new ArrayList<>();
+
+        if (userId == null) {
+            reasons.add(reason(
+                    "MISSION_WEIGHT_DEFAULT_PROFILE",
+                    candidateCount,
+                    candidateCount,
+                    "No userId supplied. Category weights default to 1.0."
+            ));
+        } else if (preferenceProfile == null || !preferenceProfile.hasSignals()) {
+            reasons.add(reason(
+                    "MISSION_WEIGHT_NO_SIGNALS",
+                    candidateCount,
+                    candidateCount,
+                    "userId=" + userId + " but no saved/liked/completed/cancelled signals were found."
+            ));
+        } else {
+            reasons.add(reason(
+                    "MISSION_WEIGHT_PROFILE_APPLIED",
+                    candidateCount,
+                    candidateCount,
+                    String.format(
+                            "userId=%d, signals=%d, topSignals=%s",
+                            userId,
+                            preferenceProfile.signals().size(),
+                            preferenceProfile.signals().stream()
+                                    .limit(3)
+                                    .map(signal -> signal.signalType() + ":" + signal.key() + "(" + signal.delta() + ")")
+                                    .collect(Collectors.joining(", "))
+                    )
+            ));
+        }
+
+        reasons.add(reason(
+                "MISSION_WEIGHTED_RANDOM_SELECTION",
+                candidateCount,
+                selectionResult.selected() != null ? 1 : 0,
+                String.format(
+                        "selectedPoint=%.3f,totalWeight=%.3f,randomFraction=%.3f,selectedMissionId=%s",
+                        selectionResult.selectedPoint(),
+                        selectionResult.totalWeight(),
+                        selectionResult.randomFraction(),
+                        selectionResult.selected() != null ? selectionResult.selected().mission().getId() : "none"
+                )
+        ));
+
+        Long selectedMissionId = selectionResult.selected() != null
+                ? selectionResult.selected().mission().getId()
+                : null;
+        List<SimulationResponse.SelectionInfo> selections = selectionResult.rankedCandidates().stream()
+                .limit(5)
+                .map(candidate -> selection(
+                        "MISSION_CANDIDATE",
+                        candidate.mission().getId(),
+                        candidate.mission().getTitle(),
+                        candidate.mission().getCategory().name(),
+                        String.format(
+                                "categoryWeight=%.2f%s",
+                                candidate.categoryWeight(),
+                                candidate.mission().getId() != null && candidate.mission().getId().equals(selectedMissionId)
+                                        ? ", selected=true"
+                                        : ""
+                        )
+                ))
+                .collect(Collectors.toList());
+
+        return stage(
+                "MISSION_WEIGHTED_SELECTION",
+                "Mission: weighted selection",
+                "MISSION",
+                candidateCount,
+                selectionResult.selected() != null ? 1 : 0,
+                reasons,
+                selections
+        );
+    }
+
+    private List<MissionCategory> getCategoryMapping(MissionCategory missionCategory) {
+        return recommendationSupportService.mapMissionToPlaceCategories(missionCategory);
+    }
+
+    private record MissionFilterResult(
+            List<MissionTemplate> candidates,
+            int totalCount,
+            List<SimulationResponse.StageInfo> stages
+    ) {
+    }
+
+    private record PlaceFilterResult(
+            List<Place> candidates,
+            int totalCount,
+            List<SimulationResponse.StageInfo> stages
+    ) {
+    }
+
+    private record FilterOutcome<T>(
+            List<T> candidates,
+            List<SimulationResponse.ReasonInfo> reasons
+    ) {
     }
 }

--- a/backend/src/main/java/com/littleescape/api/service/simulation/EnvironmentContext.java
+++ b/backend/src/main/java/com/littleescape/api/service/simulation/EnvironmentContext.java
@@ -2,6 +2,7 @@ package com.littleescape.api.service.simulation;
 
 import com.littleescape.api.domain.type.AirQuality;
 import com.littleescape.api.domain.type.Congestion;
+import com.littleescape.api.domain.type.RecommendationRadiusPolicy;
 import com.littleescape.api.domain.type.Weather;
 import lombok.Builder;
 import lombok.Getter;
@@ -9,66 +10,87 @@ import lombok.Getter;
 import java.time.DayOfWeek;
 import java.time.LocalDateTime;
 
-/**
- * 환경 컨텍스트 - 실제 서비스와 시뮬레이션 모두에서 사용
- * 추천 로직에 필요한 모든 환경 변수를 캡슐화
- */
 @Getter
 @Builder
 public class EnvironmentContext {
 
-    // 시간 관련
+    public static final int DEFAULT_REALTIME_SEARCH_RADIUS_KM = RecommendationRadiusPolicy.DEFAULT_SEARCH_RADIUS_KM;
+    public static final Weather DEFAULT_REALTIME_WEATHER = Weather.SUNNY;
+    public static final double DEFAULT_REALTIME_TEMPERATURE_C = 20.0;
+    public static final AirQuality DEFAULT_REALTIME_AIR_QUALITY = AirQuality.GOOD;
+    public static final Congestion DEFAULT_REALTIME_CONGESTION = Congestion.NORMAL;
+
     private LocalDateTime targetDateTime;
     private DayOfWeek dayOfWeek;
     private int hour;
 
-    // 위치 관련
     private Double latitude;
     private Double longitude;
     private Integer searchRadius;
 
-    // 날씨 관련
     private Weather weather;
     private Double temperature;
     private AirQuality airQuality;
 
-    // 혼잡도
     private Congestion congestion;
 
-    // 사용자 정보
     private String userMbti;
     private String userTags;
 
-    /**
-     * 실제 운영 환경 컨텍스트 생성 (현재 시간 기준)
-     */
+    public static int resolveSearchRadius(Integer searchRadius) {
+        return RecommendationRadiusPolicy.resolveSearchRadius(searchRadius);
+    }
+
     public static EnvironmentContext fromRealTime(
+            LocalDateTime targetDateTime,
             Double latitude,
             Double longitude,
+            Integer searchRadius,
+            Weather weather,
+            Double temperature,
+            AirQuality airQuality,
+            Congestion congestion,
             String userMbti,
-            String userTags) {
-
-        LocalDateTime now = LocalDateTime.now();
+            String userTags
+    ) {
+        LocalDateTime effectiveDateTime = targetDateTime != null ? targetDateTime : LocalDateTime.now();
 
         return EnvironmentContext.builder()
-                .targetDateTime(now)
-                .dayOfWeek(now.getDayOfWeek())
-                .hour(now.getHour())
+                .targetDateTime(effectiveDateTime)
+                .dayOfWeek(effectiveDateTime.getDayOfWeek())
+                .hour(effectiveDateTime.getHour())
                 .latitude(latitude)
                 .longitude(longitude)
-                .searchRadius(10) // 기본 반경 10km
-                .weather(Weather.SUNNY) // TODO: 실제 날씨 API 연동
-                .temperature(20.0) // TODO: 실제 기온 데이터
-                .airQuality(AirQuality.GOOD) // TODO: 실제 미세먼지 데이터
-                .congestion(Congestion.LOW) // TODO: 실제 혼잡도 데이터
+                .searchRadius(resolveSearchRadius(searchRadius))
+                .weather(weather != null ? weather : DEFAULT_REALTIME_WEATHER)
+                .temperature(temperature != null ? temperature : DEFAULT_REALTIME_TEMPERATURE_C)
+                .airQuality(airQuality != null ? airQuality : DEFAULT_REALTIME_AIR_QUALITY)
+                .congestion(congestion != null ? congestion : DEFAULT_REALTIME_CONGESTION)
                 .userMbti(userMbti)
                 .userTags(userTags)
                 .build();
     }
 
-    /**
-     * 시뮬레이션 환경 컨텍스트 생성 (모든 변수 통제)
-     */
+    public static EnvironmentContext fromRealTime(
+            Double latitude,
+            Double longitude,
+            String userMbti,
+            String userTags
+    ) {
+        return fromRealTime(
+                LocalDateTime.now(),
+                latitude,
+                longitude,
+                DEFAULT_REALTIME_SEARCH_RADIUS_KM,
+                DEFAULT_REALTIME_WEATHER,
+                DEFAULT_REALTIME_TEMPERATURE_C,
+                DEFAULT_REALTIME_AIR_QUALITY,
+                DEFAULT_REALTIME_CONGESTION,
+                userMbti,
+                userTags
+        );
+    }
+
     public static EnvironmentContext fromSimulation(
             LocalDateTime targetDateTime,
             Double latitude,
@@ -79,15 +101,15 @@ public class EnvironmentContext {
             AirQuality airQuality,
             Congestion congestion,
             String userMbti,
-            String userTags) {
-
+            String userTags
+    ) {
         return EnvironmentContext.builder()
                 .targetDateTime(targetDateTime)
                 .dayOfWeek(targetDateTime.getDayOfWeek())
                 .hour(targetDateTime.getHour())
                 .latitude(latitude)
                 .longitude(longitude)
-                .searchRadius(searchRadius)
+                .searchRadius(resolveSearchRadius(searchRadius))
                 .weather(weather)
                 .temperature(temperature)
                 .airQuality(airQuality)
@@ -97,47 +119,42 @@ public class EnvironmentContext {
                 .build();
     }
 
-    /**
-     * 야외 활동 제한 여부 판단
-     */
     public boolean isOutdoorRestricted() {
-        // 비/눈이 오거나 미세먼지가 매우 나쁘거나 극한 기온
         return weather == Weather.RAIN
                 || weather == Weather.SNOW
                 || airQuality == AirQuality.WORST
-                || temperature < -5.0
-                || temperature > 30.0;
+                || (temperature != null && temperature < -5.0)
+                || (temperature != null && temperature > 30.0);
     }
 
-    /**
-     * 실내 활동 우선 여부 판단
-     */
     public boolean isIndoorPreferred() {
-        // 비/눈 또는 미세먼지 나쁨
         return weather == Weather.RAIN
                 || weather == Weather.SNOW
                 || airQuality == AirQuality.BAD
                 || airQuality == AirQuality.WORST;
     }
 
-    /**
-     * 조용한 장소 선호 여부 (혼잡도 높을 때)
-     */
     public boolean prefersQuietPlace() {
         return congestion == Congestion.HIGH;
     }
 
-    /**
-     * 월요일 여부 (도서관 휴무일)
-     */
     public boolean isMonday() {
         return dayOfWeek == DayOfWeek.MONDAY;
     }
 
-    /**
-     * 야간 시간 여부 (22시 이후)
-     */
     public boolean isLateNight() {
         return hour >= 22;
+    }
+
+    public boolean hasUserTags() {
+        return userTags != null && !userTags.isBlank();
+    }
+
+    public boolean isIntrovert() {
+        return userMbti != null && userMbti.toUpperCase().startsWith("I");
+    }
+
+    public boolean isExtrovert() {
+        return userMbti != null && userMbti.toUpperCase().startsWith("E");
     }
 }

--- a/backend/src/test/java/com/littleescape/api/service/MissionRecommendationSelectionServiceTest.java
+++ b/backend/src/test/java/com/littleescape/api/service/MissionRecommendationSelectionServiceTest.java
@@ -1,0 +1,80 @@
+package com.littleescape.api.service;
+
+import com.littleescape.api.domain.MissionTemplate;
+import com.littleescape.api.domain.type.LocationType;
+import com.littleescape.api.domain.type.MissionCategory;
+import com.littleescape.api.domain.type.TimeOfDay;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class MissionRecommendationSelectionServiceTest {
+
+    @Test
+    void selectMission_prefersHigherCategoryWeightWhenRollIsLow() {
+        MissionRecommendationSelectionService service =
+                new MissionRecommendationSelectionService(() -> 0.05);
+
+        MissionTemplate relaxMission = mission(1L, "Relax Mission", MissionCategory.RELAX);
+        MissionTemplate foodMission = mission(2L, "Food Mission", MissionCategory.FOOD);
+
+        RecommendationPreferenceService.UserPreferenceProfile profile =
+                new RecommendationPreferenceService.UserPreferenceProfile(
+                        Map.of(MissionCategory.RELAX, 2.0, MissionCategory.FOOD, 1.0),
+                        Map.of(),
+                        List.of()
+                );
+
+        MissionRecommendationSelectionService.MissionSelectionResult result = service.selectMission(
+                List.of(foodMission, relaxMission),
+                profile
+        );
+
+        assertThat(result.rankedCandidates())
+                .extracting(candidate -> candidate.mission().getId())
+                .containsExactly(1L, 2L);
+        assertThat(result.selected().mission().getId()).isEqualTo(1L);
+        assertThat(result.totalWeight()).isEqualTo(3.0);
+    }
+
+    @Test
+    void selectMission_canSelectLowerWeightCandidateWhenRollFallsInItsRange() {
+        MissionRecommendationSelectionService service =
+                new MissionRecommendationSelectionService(() -> 0.95);
+
+        MissionTemplate relaxMission = mission(1L, "Relax Mission", MissionCategory.RELAX);
+        MissionTemplate foodMission = mission(2L, "Food Mission", MissionCategory.FOOD);
+
+        RecommendationPreferenceService.UserPreferenceProfile profile =
+                new RecommendationPreferenceService.UserPreferenceProfile(
+                        Map.of(MissionCategory.RELAX, 2.0, MissionCategory.FOOD, 1.0),
+                        Map.of(),
+                        List.of()
+                );
+
+        MissionRecommendationSelectionService.MissionSelectionResult result = service.selectMission(
+                List.of(foodMission, relaxMission),
+                profile
+        );
+
+        assertThat(result.selected().mission().getId()).isEqualTo(2L);
+        assertThat(result.selectedPoint()).isGreaterThan(2.0);
+        assertThat(result.selectedPoint()).isLessThan(result.totalWeight());
+    }
+
+    private MissionTemplate mission(Long id, String title, MissionCategory category) {
+        MissionTemplate mission = new MissionTemplate();
+        mission.setId(id);
+        mission.setTitle(title);
+        mission.setDescription(title + " description");
+        mission.setCategory(category);
+        mission.setDifficultyLevel("MEDIUM");
+        mission.setLocationType(LocationType.ANY);
+        mission.setTimeOfDay(TimeOfDay.ANY);
+        mission.setIsPlaceRequired(false);
+        return mission;
+    }
+}

--- a/backend/src/test/java/com/littleescape/api/service/PlaceRecommendationScoringServiceTest.java
+++ b/backend/src/test/java/com/littleescape/api/service/PlaceRecommendationScoringServiceTest.java
@@ -1,0 +1,316 @@
+package com.littleescape.api.service;
+
+import com.littleescape.api.domain.Place;
+import com.littleescape.api.domain.PlaceDetailPerformance;
+import com.littleescape.api.domain.type.DataSource;
+import com.littleescape.api.domain.type.MissionCategory;
+import com.littleescape.api.domain.type.AirQuality;
+import com.littleescape.api.domain.type.Congestion;
+import com.littleescape.api.domain.type.Weather;
+import com.littleescape.api.service.simulation.EnvironmentContext;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class PlaceRecommendationScoringServiceTest {
+
+    private final PlaceRecommendationScoringService scoringService =
+            new PlaceRecommendationScoringService(
+                    new RecommendationSupportService(),
+                    new RecommendationTagConflictService()
+            );
+
+    @Test
+    void selectTopPlace_prefersCloserAffordableQuietMatch() {
+        Place quietFreePlace = place(
+                "Quiet Free Studio",
+                37.5000,
+                127.0000,
+                MissionCategory.CULTURE,
+                "QUIET",
+                true,
+                DataSource.MANUAL,
+                null
+        );
+        Place loudPaidPlace = place(
+                "Loud Paid Hall",
+                37.5010,
+                127.0010,
+                MissionCategory.CULTURE,
+                null,
+                false,
+                DataSource.KOPIS,
+                25000
+        );
+        Place farLibrary = place(
+                "Far Library",
+                37.5600,
+                127.0600,
+                MissionCategory.CULTURE,
+                "QUIET",
+                true,
+                DataSource.LIBRARY,
+                null
+        );
+
+        PlaceRecommendationScoringService.PlaceSelectionResult result = scoringService.selectTopPlace(
+                List.of(loudPaidPlace, farLibrary, quietFreePlace),
+                new PlaceRecommendationScoringService.PlaceRankingContext(
+                        MissionCategory.CULTURE,
+                        "PREFER_QUIET",
+                        37.5000,
+                        127.0000,
+                        10,
+                        EnvironmentContext.fromSimulation(
+                                LocalDate.now().atStartOfDay(),
+                                37.5000,
+                                127.0000,
+                                10,
+                                Weather.CLOUDY,
+                                22.0,
+                                AirQuality.GOOD,
+                                Congestion.HIGH,
+                                "I",
+                                "PREFER_QUIET"
+                        ),
+                        null
+                )
+        );
+
+        assertThat(result.selected()).isNotNull();
+        assertThat(result.selected().place().getName()).isEqualTo("Quiet Free Studio");
+        assertThat(result.tieBreakApplied()).isFalse();
+        assertThat(result.rankedCandidates().get(0).components())
+                .extracting(PlaceRecommendationScoringService.ScoreComponent::code)
+                .containsExactly("DISTANCE", "MISSION_CATEGORY_FIT", "PRICE_ACCESSIBILITY", "QUIET_PREFERENCE", "DATA_SOURCE");
+    }
+
+    @Test
+    void selectTopPlace_randomTieBreakOnlyWhenTopScoresTie() {
+        Place firstTopCandidate = place(
+                "Top Candidate A",
+                37.5000,
+                127.0000,
+                MissionCategory.RELAX,
+                null,
+                true,
+                DataSource.MANUAL,
+                null
+        );
+        Place secondTopCandidate = place(
+                "Top Candidate B",
+                37.5000,
+                127.0000,
+                MissionCategory.RELAX,
+                null,
+                true,
+                DataSource.MANUAL,
+                null
+        );
+        Place lowerCandidate = place(
+                "Lower Candidate",
+                37.5300,
+                127.0300,
+                MissionCategory.CULTURE,
+                null,
+                false,
+                DataSource.LIBRARY,
+                30000
+        );
+
+        PlaceRecommendationScoringService.PlaceSelectionResult result = scoringService.selectTopPlace(
+                List.of(firstTopCandidate, secondTopCandidate, lowerCandidate),
+                new PlaceRecommendationScoringService.PlaceRankingContext(
+                        MissionCategory.RELAX,
+                        null,
+                        37.5000,
+                        127.0000,
+                        10,
+                        EnvironmentContext.fromSimulation(
+                                LocalDate.now().atStartOfDay(),
+                                37.5000,
+                                127.0000,
+                                10,
+                                Weather.SUNNY,
+                                18.0,
+                                AirQuality.GOOD,
+                                Congestion.NORMAL,
+                                "E",
+                                null
+                        ),
+                        null
+                )
+        );
+
+        assertThat(result.tieBreakApplied()).isTrue();
+        assertThat(result.tieCandidateCount()).isEqualTo(2);
+        assertThat(result.selected().place().getName())
+                .isIn("Top Candidate A", "Top Candidate B");
+        assertThat(result.rankedCandidates().get(0).totalScore())
+                .isEqualTo(result.rankedCandidates().get(1).totalScore());
+        assertThat(result.rankedCandidates().get(1).totalScore())
+                .isGreaterThan(result.rankedCandidates().get(2).totalScore());
+    }
+
+    @Test
+    void rankPlaces_adjustsLibraryScoreForHighCongestionIntrovertContext() {
+        Place quietLibrary = place(
+                "Quiet Library",
+                37.5000,
+                127.0000,
+                MissionCategory.CULTURE,
+                "QUIET",
+                true,
+                DataSource.LIBRARY,
+                null
+        );
+        Place generalCulturePlace = place(
+                "General Culture Hall",
+                37.5000,
+                127.0000,
+                MissionCategory.CULTURE,
+                null,
+                true,
+                DataSource.SEOUL_CULTURE,
+                null
+        );
+
+        List<PlaceRecommendationScoringService.PlaceScore> ranked = scoringService.rankPlaces(
+                List.of(generalCulturePlace, quietLibrary),
+                new PlaceRecommendationScoringService.PlaceRankingContext(
+                        MissionCategory.CULTURE,
+                        null,
+                        37.5000,
+                        127.0000,
+                        10,
+                        EnvironmentContext.fromSimulation(
+                                LocalDate.now().atStartOfDay(),
+                                37.5000,
+                                127.0000,
+                                10,
+                                Weather.CLOUDY,
+                                18.0,
+                                AirQuality.GOOD,
+                                Congestion.HIGH,
+                                "I",
+                                null
+                        ),
+                        null
+                )
+        );
+
+        PlaceRecommendationScoringService.PlaceScore libraryScore = ranked.stream()
+                .filter(score -> "Quiet Library".equals(score.place().getName()))
+                .findFirst()
+                .orElseThrow();
+
+        assertThat(libraryScore.components())
+                .filteredOn(component -> "DATA_SOURCE".equals(component.code()))
+                .singleElement()
+                .extracting(PlaceRecommendationScoringService.ScoreComponent::detail)
+                .asString()
+                .contains("HIGH + I");
+    }
+
+    @Test
+    void rankPlaces_appliesPreferenceProfileToCategoryAndSourceScores() {
+        Place preferredPlace = place(
+                "Preferred Library",
+                37.5000,
+                127.0000,
+                MissionCategory.RELAX,
+                "QUIET",
+                true,
+                DataSource.LIBRARY,
+                null
+        );
+        Place discouragedPlace = place(
+                "Discouraged Park",
+                37.5000,
+                127.0000,
+                MissionCategory.FOOD,
+                null,
+                true,
+                DataSource.SEOUL_PARK,
+                null
+        );
+
+        RecommendationPreferenceService.UserPreferenceProfile preferenceProfile =
+                new RecommendationPreferenceService.UserPreferenceProfile(
+                        Map.of(
+                                MissionCategory.FOOD, 0.5,
+                                MissionCategory.ACTIVITY, 1.0,
+                                MissionCategory.RELAX, 1.4,
+                                MissionCategory.CULTURE, 1.0
+                        ),
+                        Map.of(
+                                DataSource.LIBRARY, 1.3,
+                                DataSource.SEOUL_PARK, 0.7,
+                                DataSource.KOPIS, 1.0,
+                                DataSource.SEOUL_CULTURE, 1.0,
+                                DataSource.SEOUL_RESERVATION, 1.0,
+                                DataSource.SEOUL_RESTAURANT, 1.0,
+                                DataSource.MANUAL, 1.0
+                        ),
+                        List.of()
+                );
+
+        List<PlaceRecommendationScoringService.PlaceScore> ranked = scoringService.rankPlaces(
+                List.of(discouragedPlace, preferredPlace),
+                new PlaceRecommendationScoringService.PlaceRankingContext(
+                        MissionCategory.RELAX,
+                        null,
+                        37.5000,
+                        127.0000,
+                        10,
+                        null,
+                        preferenceProfile
+                )
+        );
+
+        assertThat(ranked.get(0).place().getName()).isEqualTo("Preferred Library");
+        assertThat(ranked.get(0).components())
+                .filteredOn(component -> "DATA_SOURCE".equals(component.code()))
+                .singleElement()
+                .extracting(PlaceRecommendationScoringService.ScoreComponent::detail)
+                .asString()
+                .contains("preferenceWeight=1.3");
+    }
+
+    private Place place(String name,
+                        double latitude,
+                        double longitude,
+                        MissionCategory category,
+                        String tags,
+                        boolean isFree,
+                        DataSource dataSource,
+                        Integer ticketPrice) {
+        Place place = Place.builder()
+                .name(name)
+                .address(name + " address")
+                .url("https://example.com/" + name.replace(' ', '-'))
+                .latitude(latitude)
+                .longitude(longitude)
+                .category(category)
+                .tags(tags)
+                .isFree(isFree)
+                .dataSource(dataSource)
+                .isActive(true)
+                .build();
+
+        if (ticketPrice != null) {
+            place.setPerformanceDetail(PlaceDetailPerformance.builder()
+                    .startDate(LocalDate.now().minusDays(1))
+                    .endDate(LocalDate.now().plusDays(7))
+                    .ticketPrice(ticketPrice)
+                    .performanceState("RUNNING")
+                    .build());
+        }
+
+        return place;
+    }
+}

--- a/backend/src/test/java/com/littleescape/api/service/PlaceScheduleFilterServiceTest.java
+++ b/backend/src/test/java/com/littleescape/api/service/PlaceScheduleFilterServiceTest.java
@@ -1,0 +1,108 @@
+package com.littleescape.api.service;
+
+import com.littleescape.api.domain.Place;
+import com.littleescape.api.domain.PlaceDetailFacility;
+import com.littleescape.api.domain.PlaceDetailPerformance;
+import com.littleescape.api.domain.type.MissionCategory;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class PlaceScheduleFilterServiceTest {
+
+    private final PlaceScheduleFilterService service = new PlaceScheduleFilterService();
+
+    @Test
+    void filterPlacesBySchedule_excludesNotStartedPerformance() {
+        Place performancePlace = place("Future Performance");
+        performancePlace.setPerformanceDetail(PlaceDetailPerformance.builder()
+                .startDate(LocalDate.of(2025, 1, 10))
+                .endDate(LocalDate.of(2025, 1, 31))
+                .performanceState("UPCOMING")
+                .build());
+
+        PlaceScheduleFilterService.PlaceScheduleFilterResult result = service.filterPlacesBySchedule(
+                java.util.List.of(performancePlace),
+                LocalDateTime.of(2025, 1, 5, 19, 0),
+                LocalDate.of(2025, 1, 5)
+        );
+
+        assertThat(result.afterCount()).isZero();
+        assertThat(result.notStartedCount()).isEqualTo(1);
+        assertThat(result.exclusionDetails())
+                .extracting(PlaceScheduleFilterService.ScheduleFilterDecision::reasonCode)
+                .containsExactly("EXCLUDE_NOT_YET_STARTED");
+    }
+
+    @Test
+    void filterPlacesBySchedule_excludesClosedDay() {
+        Place library = place("Monday Closed Library");
+        library.setFacilityDetail(PlaceDetailFacility.builder()
+                .closedDays("매주 월요일")
+                .operatingTime("09:00-18:00")
+                .build());
+
+        PlaceScheduleFilterService.PlaceScheduleFilterResult result = service.filterPlacesBySchedule(
+                java.util.List.of(library),
+                LocalDateTime.of(2025, 1, 6, 10, 0),
+                LocalDate.of(2025, 1, 6)
+        );
+
+        assertThat(result.afterCount()).isZero();
+        assertThat(result.closedDayCount()).isEqualTo(1);
+        assertThat(result.exclusionDetails().get(0).reasonCode()).isEqualTo("EXCLUDE_CLOSED_DAY");
+    }
+
+    @Test
+    void filterPlacesBySchedule_excludesOutsideOperatingHours() {
+        Place facility = place("Daytime Facility");
+        facility.setFacilityDetail(PlaceDetailFacility.builder()
+                .operatingTime("09:00-18:00")
+                .closedDays("없음")
+                .build());
+
+        PlaceScheduleFilterService.PlaceScheduleFilterResult result = service.filterPlacesBySchedule(
+                java.util.List.of(facility),
+                LocalDateTime.of(2025, 1, 7, 20, 0),
+                LocalDate.of(2025, 1, 7)
+        );
+
+        assertThat(result.afterCount()).isZero();
+        assertThat(result.outsideOperatingHoursCount()).isEqualTo(1);
+        assertThat(result.exclusionDetails().get(0).reasonCode()).isEqualTo("EXCLUDE_OUTSIDE_OPERATING_HOURS");
+    }
+
+    @Test
+    void filterPlacesBySchedule_keepsPlaceWhenOperationalInfoIsUnparseable() {
+        Place facility = place("Unknown Hours Facility");
+        facility.setFacilityDetail(PlaceDetailFacility.builder()
+                .operatingTime("문의 후 방문")
+                .closedDays("공휴일")
+                .build());
+
+        PlaceScheduleFilterService.PlaceScheduleFilterResult result = service.filterPlacesBySchedule(
+                java.util.List.of(facility),
+                LocalDateTime.of(2025, 1, 7, 14, 0),
+                LocalDate.of(2025, 1, 7)
+        );
+
+        assertThat(result.afterCount()).isEqualTo(1);
+        assertThat(result.unknownOperationalInfoCount()).isEqualTo(1);
+        assertThat(result.exclusionDetails()).isEmpty();
+    }
+
+    private Place place(String name) {
+        return Place.builder()
+                .name(name)
+                .address(name + " address")
+                .url("https://example.com/" + name.replace(' ', '-'))
+                .latitude(37.5)
+                .longitude(127.0)
+                .category(MissionCategory.CULTURE)
+                .isActive(true)
+                .build();
+    }
+}

--- a/backend/src/test/java/com/littleescape/api/service/RecommendationPreferenceServiceTest.java
+++ b/backend/src/test/java/com/littleescape/api/service/RecommendationPreferenceServiceTest.java
@@ -1,0 +1,85 @@
+package com.littleescape.api.service;
+
+import com.littleescape.api.domain.type.AppointmentStatus;
+import com.littleescape.api.domain.type.DataSource;
+import com.littleescape.api.domain.type.MissionCategory;
+import com.littleescape.api.repository.AppointmentRepository;
+import com.littleescape.api.repository.LikedAppointmentRepository;
+import com.littleescape.api.repository.SavedAppointmentRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class RecommendationPreferenceServiceTest {
+
+    @Mock
+    private SavedAppointmentRepository savedAppointmentRepository;
+
+    @Mock
+    private LikedAppointmentRepository likedAppointmentRepository;
+
+    @Mock
+    private AppointmentRepository appointmentRepository;
+
+    @Test
+    void buildProfile_combinesPositiveAndNegativeSignals() {
+        RecommendationPreferenceService service = new RecommendationPreferenceService(
+                savedAppointmentRepository,
+                likedAppointmentRepository,
+                appointmentRepository
+        );
+
+        when(savedAppointmentRepository.findCategoryStatsByUserId(1L))
+                .thenReturn(List.<Object[]>of(
+                        new Object[]{MissionCategory.RELAX, 3L},
+                        new Object[]{MissionCategory.CULTURE, 1L}
+                ));
+        when(likedAppointmentRepository.findCategoryStatsByUserId(1L))
+                .thenReturn(List.<Object[]>of(
+                        new Object[]{MissionCategory.CULTURE, 2L}
+                ));
+        when(appointmentRepository.findCategoryStatsByUserIdAndStatuses(eq(1L), eq(List.of(AppointmentStatus.COMPLETED))))
+                .thenReturn(List.<Object[]>of(
+                        new Object[]{MissionCategory.RELAX, 2L}
+                ));
+        when(appointmentRepository.findCategoryStatsByUserIdAndStatuses(eq(1L), eq(List.of(AppointmentStatus.CANCELLED))))
+                .thenReturn(List.<Object[]>of(
+                        new Object[]{MissionCategory.FOOD, 2L}
+                ));
+
+        when(savedAppointmentRepository.findPlaceDataSourceStatsByUserId(1L))
+                .thenReturn(List.<Object[]>of(
+                        new Object[]{DataSource.LIBRARY, 2L}
+                ));
+        when(likedAppointmentRepository.findPlaceDataSourceStatsByUserId(1L))
+                .thenReturn(List.<Object[]>of(
+                        new Object[]{DataSource.SEOUL_CULTURE, 1L}
+                ));
+        when(appointmentRepository.findPlaceDataSourceStatsByUserIdAndStatuses(eq(1L), eq(List.of(AppointmentStatus.COMPLETED))))
+                .thenReturn(List.<Object[]>of(
+                        new Object[]{DataSource.LIBRARY, 1L}
+                ));
+        when(appointmentRepository.findPlaceDataSourceStatsByUserIdAndStatuses(eq(1L), eq(List.of(AppointmentStatus.CANCELLED))))
+                .thenReturn(List.<Object[]>of(
+                        new Object[]{DataSource.SEOUL_PARK, 2L}
+                ));
+
+        RecommendationPreferenceService.UserPreferenceProfile profile = service.buildProfile(1L);
+
+        assertThat(profile.categoryWeight(MissionCategory.RELAX))
+                .isGreaterThan(profile.categoryWeight(MissionCategory.CULTURE))
+                .isGreaterThan(profile.categoryWeight(MissionCategory.FOOD));
+        assertThat(profile.categoryWeight(MissionCategory.FOOD)).isLessThan(1.0);
+        assertThat(profile.dataSourceWeight(DataSource.LIBRARY))
+                .isGreaterThan(profile.dataSourceWeight(DataSource.SEOUL_PARK));
+        assertThat(profile.signals()).isNotEmpty();
+    }
+}

--- a/backend/src/test/java/com/littleescape/api/service/simulation/EnvironmentContextTest.java
+++ b/backend/src/test/java/com/littleescape/api/service/simulation/EnvironmentContextTest.java
@@ -1,0 +1,50 @@
+package com.littleescape.api.service.simulation;
+
+import com.littleescape.api.domain.type.AirQuality;
+import com.littleescape.api.domain.type.Congestion;
+import com.littleescape.api.domain.type.RecommendationRadiusPolicy;
+import com.littleescape.api.domain.type.Weather;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class EnvironmentContextTest {
+
+    @Test
+    void fromRealTime_usesSharedDefaultRadiusWhenMissing() {
+        EnvironmentContext context = EnvironmentContext.fromRealTime(
+                LocalDateTime.of(2025, 1, 20, 14, 30),
+                37.5665,
+                126.9780,
+                null,
+                Weather.SUNNY,
+                20.0,
+                AirQuality.GOOD,
+                Congestion.NORMAL,
+                "I",
+                null
+        );
+
+        assertThat(context.getSearchRadius()).isEqualTo(RecommendationRadiusPolicy.DEFAULT_SEARCH_RADIUS_KM);
+    }
+
+    @Test
+    void fromSimulation_normalizesInvalidRadiusWithSameRule() {
+        EnvironmentContext context = EnvironmentContext.fromSimulation(
+                LocalDateTime.of(2025, 1, 20, 14, 30),
+                37.5665,
+                126.9780,
+                0,
+                Weather.CLOUDY,
+                18.0,
+                AirQuality.BAD,
+                Congestion.HIGH,
+                "E",
+                "NO_ALCOHOL"
+        );
+
+        assertThat(context.getSearchRadius()).isEqualTo(RecommendationRadiusPolicy.DEFAULT_SEARCH_RADIUS_KM);
+    }
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -37,6 +37,8 @@ import Contact from './pages/Contact';
 import SavedAppointments from './pages/SavedAppointments';
 import SavedDetail from './pages/SavedDetail';
 import ArchivedAppointmentDetail from './pages/ArchivedAppointmentDetail';
+import { getNextAppointment } from './api/appointmentApi';
+import { getAppointmentNavigationPath } from './utils/appointmentNavigation';
 
 // 보호된 라우트 컴포넌트
 const ProtectedRoute = ({ children }: { children: ReactNode }) => {
@@ -56,47 +58,62 @@ const GlobalRedirectWrapper = ({ children }: { children: ReactNode }) => {
   const navigate = useNavigate();
 
   useEffect(() => {
-    const appointmentId = localStorage.getItem('appointmentId');
-    const onboardingComplete = localStorage.getItem('onboarding_complete');
-    const currentPath = location.pathname;
+    let cancelled = false;
 
-    console.log('=== GlobalRedirectWrapper 체크 ===');
-    console.log('현재 경로:', currentPath);
-    console.log('약속 ID:', appointmentId);
-    console.log('온보딩 완료:', onboardingComplete === 'true');
+    const validateRedirect = async () => {
+      const appointmentId = localStorage.getItem('appointmentId');
+      const onboardingComplete = localStorage.getItem('onboarding_complete');
+      const currentPath = location.pathname;
 
-    // 예외 경로: 피드, 마이페이지, 약속 목록, 로그인, 약속 설정 플로우 등은 체크 안 함
-    const exemptPaths = ['/feed', '/mypage', '/appointments', '/reviews', '/mission', '/login', '/oauth/callback', '/auth/callback', '/magic-login', '/dev-console', '/profile-edit', '/contact', '/mypage/saved', '/saved/detail', '/location', '/time-picker'];
-    if (exemptPaths.some(path => currentPath.startsWith(path))) {
-      console.log('✅ 예외 경로 - 리다이렉트 skip');
-      return;
-    }
+      console.log('=== GlobalRedirectWrapper 체크 ===');
+      console.log('현재 경로:', currentPath);
+      console.log('약속 ID:', appointmentId);
+      console.log('온보딩 완료:', onboardingComplete === 'true');
 
-    // 약속 ID 유효성 검사
-    const isValidAppointmentId = appointmentId && 
-                                 appointmentId !== 'null' && 
-                                 appointmentId !== 'undefined' && 
-                                 appointmentId.trim() !== '' && 
-                                 !isNaN(Number(appointmentId));
-
-    // 1순위: 약속 있음 -> 채팅 온보딩에 있으면 미션으로 납치
-    // 단, /location, /time-picker는 약속 설정 플로우이므로 예외
-    if (isValidAppointmentId) {
-      if (currentPath.startsWith('/chat') || currentPath.startsWith('/onboarding')) {
-        console.log('🎯 약속 있는데 온보딩 접근 시도 -> /mission으로 납치!');
-        navigate(`/mission/${appointmentId}`, { replace: true });
+      // 예외 경로: 피드, 마이페이지, 약속 목록, 로그인, 약속 설정 플로우 등은 체크 안 함
+      const exemptPaths = ['/feed', '/mypage', '/appointments', '/reviews', '/mission', '/login', '/oauth/callback', '/auth/callback', '/magic-login', '/dev-console', '/profile-edit', '/contact', '/mypage/saved', '/saved/detail', '/location', '/time-picker'];
+      if (exemptPaths.some(path => currentPath.startsWith(path))) {
+        console.log('✅ 예외 경로 - 리다이렉트 skip');
         return;
       }
-    }
 
-    // 2순위: 가입 완료 -> 온보딩 접근 시 피드로 튕김
-    if (onboardingComplete === 'true') {
-      if (currentPath.startsWith('/chat') || currentPath.startsWith('/onboarding')) {
+      const isOnboardingPath = currentPath.startsWith('/chat') || currentPath.startsWith('/onboarding');
+      if (!isOnboardingPath) {
+        return;
+      }
+
+      const hasStoredAppointmentId = appointmentId &&
+        appointmentId !== 'null' &&
+        appointmentId !== 'undefined' &&
+        appointmentId.trim() !== '' &&
+        !isNaN(Number(appointmentId));
+
+      if (hasStoredAppointmentId) {
+        const nextAppointment = await getNextAppointment();
+
+        if (cancelled) {
+          return;
+        }
+
+        if (nextAppointment) {
+          console.log('🎯 유효한 진행 중 약속 확인 -> /mission으로 이동!');
+          const targetPath = getAppointmentNavigationPath(nextAppointment);
+          navigate(targetPath, { replace: true });
+          return;
+        }
+      }
+
+      if (onboardingComplete === 'true') {
         console.log('⚠️ 이미 가입한 유저가 온보딩 접근 -> /feed로 튕김!');
         navigate('/feed', { replace: true });
-        return;
       }
-    }
+    };
+
+    validateRedirect();
+
+    return () => {
+      cancelled = true;
+    };
   }, [location.pathname, navigate]);
 
   return <>{children}</>;

--- a/frontend/src/api/appointmentApi.ts
+++ b/frontend/src/api/appointmentApi.ts
@@ -1,5 +1,14 @@
 import { apiFetch } from './client';
-import { Appointment } from '../types/appointment';
+import { Appointment, AppointmentStatus } from '../types/appointment';
+
+const ACTIVE_APPOINTMENT_STATUSES = new Set<AppointmentStatus>([
+  AppointmentStatus.CREATED,
+  AppointmentStatus.UNLOCKED,
+  AppointmentStatus.PENDING,
+  AppointmentStatus.ACCEPTED,
+  AppointmentStatus.ARRIVED,
+  AppointmentStatus.IN_PROGRESS,
+]);
 
 export async function createAppointment(params: {
   scheduledAt: string;
@@ -260,11 +269,8 @@ export async function getNextAppointment(): Promise<Appointment | null> {
     console.log('📋 약속 개수:', appointments.length);
 
     // 완료되지 않은 약속만 필터링 (PENDING, ACCEPTED 포함)
-    const activeAppointments = appointments.filter(
-      (apt) => apt.status !== 'COMPLETED' &&
-               apt.status !== 'CANCELLED' &&
-               apt.status !== 'NO_SHOW' &&
-               apt.status !== 'REJECTED'
+    const activeAppointments = appointments.filter((apt) =>
+      ACTIVE_APPOINTMENT_STATUSES.has(apt.status)
     );
 
     console.log('🔄 진행 중인 약속:', activeAppointments);
@@ -272,6 +278,7 @@ export async function getNextAppointment(): Promise<Appointment | null> {
 
     if (activeAppointments.length === 0) {
       console.log('❌ 진행 중인 약속 없음');
+      localStorage.removeItem('appointmentId');
       return null;
     }
 
@@ -286,9 +293,11 @@ export async function getNextAppointment(): Promise<Appointment | null> {
     console.log('  - Mission:', sorted[0].missionTitle || '미선택');
     console.log('  - Scheduled:', sorted[0].scheduledAt);
 
+    localStorage.setItem('appointmentId', String(sorted[0].id));
     return sorted[0];
   } catch (error) {
     console.error('❌ 다음 약속 조회 실패:', error);
+    localStorage.removeItem('appointmentId');
     return null;
   }
 }

--- a/frontend/src/components/BottomNav.tsx
+++ b/frontend/src/components/BottomNav.tsx
@@ -1,6 +1,7 @@
 import { useNavigate, useLocation } from 'react-router-dom';
 import { useNextAppointment } from '../hooks/useNextAppointment';
 import { Home, Calendar, User, Zap } from 'lucide-react';
+import { getAppointmentNavigationPath } from '../utils/appointmentNavigation';
 
 const BottomNav = () => {
   const navigate = useNavigate();
@@ -12,7 +13,7 @@ const BottomNav = () => {
 
     if (appointment) {
       // 진행 중인 약속이 있으면 상세 페이지로 이동
-      navigate(`/mission/${appointment.id}`);
+      navigate(getAppointmentNavigationPath(appointment));
     } else {
       // 진행 중인 약속이 없으면 새 약속 생성 (localStorage 정리)
       localStorage.removeItem('appointmentId');

--- a/frontend/src/components/DevApiControlPanel.tsx
+++ b/frontend/src/components/DevApiControlPanel.tsx
@@ -1,0 +1,862 @@
+import { useState } from 'react';
+import axios from 'axios';
+import type { Method } from 'axios';
+
+type HttpMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE';
+type PresetCategory = 'general' | 'external-data' | 'maintenance';
+
+interface ApiPreset {
+  key: string;
+  label: string;
+  method: HttpMethod;
+  path: string;
+  description: string;
+  includeAuth?: boolean;
+  body?: string;
+  contentType?: string;
+  category: PresetCategory;
+}
+
+interface ApiResponseState {
+  status: number;
+  statusText: string;
+  durationMs: number;
+  headers: Record<string, string>;
+  body: unknown;
+  requestLabel: string;
+  requestMethod: HttpMethod;
+  requestUrl: string;
+}
+
+interface DevApiControlPanelProps {
+  apiBaseUrl: string;
+}
+
+interface ExecuteRequestOptions {
+  method: HttpMethod;
+  path: string;
+  body?: string;
+  contentType?: string;
+  includeAuth?: boolean;
+  customHeaders?: string;
+  label: string;
+  presetKey?: string;
+}
+
+interface MetricItem {
+  label: string;
+  value: string | number;
+}
+
+interface MetricSection {
+  title: string;
+  metrics: MetricItem[];
+}
+
+interface DistributionSection {
+  title: string;
+  entries: MetricItem[];
+}
+
+const API_PRESETS: ApiPreset[] = [
+  {
+    key: 'me',
+    label: '내 정보',
+    method: 'GET',
+    path: '/api/v1/users/me',
+    description: '현재 로그인한 사용자 정보 조회',
+    includeAuth: true,
+    category: 'general',
+  },
+  {
+    key: 'appointments',
+    label: '내 약속 목록',
+    method: 'GET',
+    path: '/api/v1/appointments/me',
+    description: '현재 로그인한 사용자의 약속 목록 조회',
+    includeAuth: true,
+    category: 'general',
+  },
+  {
+    key: 'simulation',
+    label: '시뮬레이션',
+    method: 'POST',
+    path: '/api/admin/simulation',
+    description: 'God Mode 시뮬레이션 API 호출',
+    includeAuth: false,
+    category: 'general',
+    body: JSON.stringify(
+      {
+        targetDateTime: new Date().toISOString().slice(0, 16),
+        latitude: 37.5665,
+        longitude: 126.978,
+        searchRadius: 10,
+        weather: 'SUNNY',
+        temperature: 20,
+        airQuality: 'GOOD',
+        congestion: 'NORMAL',
+        userMbti: 'I',
+        userId: 1,
+      },
+      null,
+      2
+    ),
+  },
+  {
+    key: 'health',
+    label: '관리 API 헬스',
+    method: 'POST',
+    path: '/api/admin/health',
+    description: '관리용 API 상태 확인',
+    includeAuth: false,
+    category: 'general',
+  },
+  {
+    key: 'ingest-all',
+    label: '전체 외부 수집',
+    method: 'POST',
+    path: '/api/admin/ingest',
+    description: '공연, 문화행사, 공원, 맛집, 도서관 수집 일괄 실행',
+    includeAuth: false,
+    category: 'external-data',
+  },
+  {
+    key: 'collect-libraries',
+    label: '도서관 수집',
+    method: 'POST',
+    path: '/api/admin/data/collect/libraries',
+    description: '도서관 API 호출 후 필터링된 장소/도서관 데이터 저장',
+    includeAuth: false,
+    category: 'external-data',
+  },
+  {
+    key: 'collect-books',
+    label: '인기 도서 수집',
+    method: 'POST',
+    path: '/api/admin/data/collect/popular-books',
+    description: '대출 인기 도서 수집',
+    includeAuth: false,
+    category: 'external-data',
+  },
+  {
+    key: 'collect-performances',
+    label: '공연/축제 수집',
+    method: 'POST',
+    path: '/api/admin/data/collect/performances',
+    description: 'KOPIS 호출 후 가격/연령/키워드 필터링 적용',
+    includeAuth: false,
+    category: 'external-data',
+  },
+  {
+    key: 'collect-events',
+    label: '문화행사 수집',
+    method: 'POST',
+    path: '/api/admin/data/collect/cultural-events',
+    description: '서울 Open Data 호출 후 문화행사 필터링 저장',
+    includeAuth: false,
+    category: 'external-data',
+  },
+  {
+    key: 'collect-parks',
+    label: '공원 수집',
+    method: 'POST',
+    path: '/api/admin/data/collect/parks',
+    description: '서울 Open Data 공원 수집 및 필터링 적용',
+    includeAuth: false,
+    category: 'external-data',
+  },
+  {
+    key: 'collect-restaurants',
+    label: '맛집 수집',
+    method: 'POST',
+    path: '/api/admin/data/collect/restaurants',
+    description: '서울 Open Data 맛집 수집',
+    includeAuth: false,
+    category: 'external-data',
+  },
+  {
+    key: 'data-stats',
+    label: '수집 통계',
+    method: 'GET',
+    path: '/api/admin/data/stats',
+    description: '현재 저장된 데이터 통계 조회',
+    includeAuth: false,
+    category: 'external-data',
+  },
+  {
+    key: 'deactivate-expired',
+    label: '종료 공연 만료',
+    method: 'POST',
+    path: '/api/admin/data/deactivate-expired',
+    description: '종료된 공연/행사를 비활성화 처리',
+    includeAuth: false,
+    category: 'maintenance',
+  },
+  {
+    key: 'check-expired-appointments',
+    label: '약속 만료 체크',
+    method: 'POST',
+    path: '/api/admin/scheduler/check-expired',
+    description: '만료된 약속을 EXPIRED 상태로 갱신',
+    includeAuth: false,
+    category: 'maintenance',
+  },
+  {
+    key: 'fix-public-status',
+    label: '공개 상태 보정',
+    method: 'POST',
+    path: '/api/admin/fix-public-status',
+    description: '완료된 약속의 공개 상태 일괄 보정',
+    includeAuth: false,
+    category: 'maintenance',
+  },
+  {
+    key: 'time-travel',
+    label: '타임 트래블',
+    method: 'PATCH',
+    path: '/api/admin/appointments/1/time-travel',
+    description: '약속 시간을 현재 시각으로 강제 이동',
+    includeAuth: false,
+    category: 'maintenance',
+  },
+  {
+    key: 'unlock-now',
+    label: '즉시 잠금 해제',
+    method: 'PUT',
+    path: '/api/v1/appointments/1/dev/unlock-now',
+    description: '약속을 지금 시점으로 잠금 해제',
+    includeAuth: true,
+    category: 'maintenance',
+  },
+  {
+    key: 'unlock-tomorrow',
+    label: '내일 잠금 해제',
+    method: 'PUT',
+    path: '/api/v1/appointments/1/dev/unlock-tomorrow',
+    description: '약속을 D-1 시점으로 이동',
+    includeAuth: true,
+    category: 'maintenance',
+  },
+];
+
+const METRIC_LABELS: Record<string, string> = {
+  inserted: '수집',
+  importedCount: '임포트',
+  updated: '업데이트',
+  updatedCount: '수정',
+  filtered: '필터링',
+  skipped: '스킵',
+  deactivatedCount: '만료 처리',
+  deletedCount: '삭제',
+  remainingCount: '잔여',
+  totalPlaces: '전체 장소',
+  activePlaces: '활성 장소',
+  totalLibraries: '도서관',
+  totalPopularBooks: '인기 도서',
+  totalPlacesCount: '전체 장소',
+  totalCompleted: '완료 약속',
+};
+
+const SECTION_LABELS: Record<string, string> = {
+  performances: '공연',
+  festivals: '축제',
+  culturalEvents: '문화행사',
+  publicReservation: '공공예약',
+  placesBySource: '소스별 장소',
+  placesByCategory: '카테고리별 장소',
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function normalizeHeaders(headers: unknown): Record<string, string> {
+  if (!isRecord(headers)) {
+    return {};
+  }
+
+  return Object.fromEntries(
+    Object.entries(headers).map(([key, value]) => {
+      if (Array.isArray(value)) {
+        return [key, value.join(', ')];
+      }
+      return [key, String(value)];
+    })
+  );
+}
+
+function getResponseTone(status: number) {
+  if (status >= 200 && status < 300) {
+    return 'bg-green-100 text-green-700 border-green-200';
+  }
+  if (status >= 400) {
+    return 'bg-red-100 text-red-700 border-red-200';
+  }
+  return 'bg-yellow-100 text-yellow-700 border-yellow-200';
+}
+
+function formatResponseBody(body: unknown) {
+  if (body === undefined || body === null || body === '') {
+    return 'No response body';
+  }
+
+  if (typeof body === 'string') {
+    return body;
+  }
+
+  try {
+    return JSON.stringify(body, null, 2);
+  } catch {
+    return String(body);
+  }
+}
+
+function toMetricLabel(key: string) {
+  return METRIC_LABELS[key] ?? key;
+}
+
+function extractMetricSections(body: unknown): MetricSection[] {
+  if (!isRecord(body)) {
+    return [];
+  }
+
+  const sections: MetricSection[] = [];
+
+  const topLevelMetrics = Object.entries(body)
+    .filter(([key, value]) => !isRecord(value) && !Array.isArray(value) && key in METRIC_LABELS)
+    .map(([key, value]) => ({
+      label: toMetricLabel(key),
+      value: typeof value === 'number' || typeof value === 'string' ? value : String(value),
+    }));
+
+  if (topLevelMetrics.length > 0) {
+    sections.push({ title: '요약', metrics: topLevelMetrics });
+  }
+
+  Object.entries(body).forEach(([key, value]) => {
+    if (!isRecord(value)) {
+      return;
+    }
+
+    const metrics = Object.entries(value)
+      .filter(([childKey, childValue]) => !isRecord(childValue) && !Array.isArray(childValue) && childKey in METRIC_LABELS)
+      .map(([childKey, childValue]) => ({
+        label: toMetricLabel(childKey),
+        value:
+          typeof childValue === 'number' || typeof childValue === 'string'
+            ? childValue
+            : String(childValue),
+      }));
+
+    if (metrics.length > 0) {
+      sections.push({
+        title: SECTION_LABELS[key] ?? key,
+        metrics,
+      });
+    }
+  });
+
+  return sections;
+}
+
+function extractDistributionSections(body: unknown): DistributionSection[] {
+  if (!isRecord(body)) {
+    return [];
+  }
+
+  return Object.entries(body)
+    .filter(([, value]) => isRecord(value))
+    .map(([key, value]) => {
+      const recordValue = value as Record<string, unknown>;
+
+      const entries = Object.entries(recordValue)
+        .filter(([, childValue]) => !isRecord(childValue) && !Array.isArray(childValue))
+        .filter(([childKey]) => !(childKey in METRIC_LABELS))
+        .map(([childKey, childValue]) => ({
+          label: childKey,
+          value:
+            typeof childValue === 'number' || typeof childValue === 'string'
+              ? childValue
+              : String(childValue),
+        }));
+
+      return {
+        title: SECTION_LABELS[key] ?? key,
+        entries,
+      };
+    })
+    .filter((section) => section.entries.length > 0);
+}
+
+function buildRequestUrl(apiBaseUrl: string, path: string) {
+  const trimmedPath = path.trim();
+  if (trimmedPath.startsWith('http://') || trimmedPath.startsWith('https://')) {
+    return trimmedPath;
+  }
+  return `${apiBaseUrl}${trimmedPath.startsWith('/') ? trimmedPath : `/${trimmedPath}`}`;
+}
+
+function getPreset(key: string) {
+  return API_PRESETS.find((preset) => preset.key === key);
+}
+
+function getPresetsByCategory(category: PresetCategory) {
+  return API_PRESETS.filter((preset) => preset.category === category);
+}
+
+const DevApiControlPanel = ({ apiBaseUrl }: DevApiControlPanelProps) => {
+  const [method, setMethod] = useState<HttpMethod>('GET');
+  const [path, setPath] = useState<string>('/api/v1/users/me');
+  const [requestBody, setRequestBody] = useState<string>('');
+  const [contentType, setContentType] = useState<string>('application/json');
+  const [customHeaders, setCustomHeaders] = useState<string>('');
+  const [includeAuth, setIncludeAuth] = useState(true);
+  const [loading, setLoading] = useState(false);
+  const [requestError, setRequestError] = useState<string | null>(null);
+  const [response, setResponse] = useState<ApiResponseState | null>(null);
+  const [activePresetKey, setActivePresetKey] = useState<string | null>(null);
+
+  const token = localStorage.getItem('token');
+  const metricSections = extractMetricSections(response?.body);
+  const distributionSections = extractDistributionSections(response?.body);
+
+  const applyPreset = (preset: ApiPreset) => {
+    setMethod(preset.method);
+    setPath(preset.path);
+    setRequestBody(preset.body ?? '');
+    setContentType(preset.contentType ?? 'application/json');
+    setIncludeAuth(preset.includeAuth ?? true);
+    setRequestError(null);
+  };
+
+  const resetResponse = () => {
+    setRequestError(null);
+    setResponse(null);
+    setActivePresetKey(null);
+  };
+
+  const executeRequest = async ({
+    method: nextMethod,
+    path: nextPath,
+    body: nextBody,
+    contentType: nextContentType,
+    includeAuth: nextIncludeAuth,
+    customHeaders: nextCustomHeaders,
+    label,
+    presetKey,
+  }: ExecuteRequestOptions) => {
+    const trimmedPath = nextPath.trim();
+    const trimmedBody = (nextBody ?? '').trim();
+    const trimmedContentType = (nextContentType ?? 'application/json').trim();
+    const trimmedHeaders = (nextCustomHeaders ?? '').trim();
+
+    if (!trimmedPath) {
+      setRequestError('요청 경로를 입력하세요.');
+      return;
+    }
+
+    if (nextMethod === 'GET' && trimmedBody) {
+      setRequestError('GET 요청은 body 없이 보내세요.');
+      return;
+    }
+
+    let parsedHeaders: Record<string, string> = {};
+    if (trimmedHeaders) {
+      try {
+        parsedHeaders = normalizeHeaders(JSON.parse(trimmedHeaders));
+      } catch {
+        setRequestError('헤더 JSON 형식이 올바르지 않습니다.');
+        return;
+      }
+    }
+
+    let data: unknown;
+    if (trimmedBody) {
+      if (trimmedContentType.includes('json')) {
+        try {
+          data = JSON.parse(trimmedBody);
+        } catch {
+          setRequestError('본문 JSON 형식이 올바르지 않습니다.');
+          return;
+        }
+      } else {
+        data = trimmedBody;
+      }
+    }
+
+    const requestUrl = buildRequestUrl(apiBaseUrl, trimmedPath);
+    const headers: Record<string, string> = {
+      'ngrok-skip-browser-warning': 'true',
+      ...parsedHeaders,
+    };
+
+    if (trimmedBody && trimmedContentType && !headers['Content-Type']) {
+      headers['Content-Type'] = trimmedContentType;
+    }
+
+    if (nextIncludeAuth && token) {
+      headers.Authorization = `Bearer ${token}`;
+    }
+
+    setLoading(true);
+    setRequestError(null);
+    setResponse(null);
+    setActivePresetKey(presetKey ?? null);
+
+    try {
+      const startedAt = performance.now();
+      const res = await axios.request({
+        url: requestUrl,
+        method: nextMethod as Method,
+        headers,
+        data,
+        validateStatus: () => true,
+      });
+      const durationMs = Math.round(performance.now() - startedAt);
+
+      setResponse({
+        status: res.status,
+        statusText: res.statusText,
+        durationMs,
+        headers: normalizeHeaders(res.headers),
+        body: res.data,
+        requestLabel: label,
+        requestMethod: nextMethod,
+        requestUrl,
+      });
+    } catch (error) {
+      if (axios.isAxiosError(error)) {
+        setRequestError(error.message);
+      } else if (error instanceof Error) {
+        setRequestError(error.message);
+      } else {
+        setRequestError('알 수 없는 요청 오류가 발생했습니다.');
+      }
+    } finally {
+      setLoading(false);
+      if (!presetKey) {
+        setActivePresetKey(null);
+      }
+    }
+  };
+
+  const handleSendRequest = async () => {
+    await executeRequest({
+      method,
+      path,
+      body: requestBody,
+      contentType,
+      includeAuth,
+      customHeaders,
+      label: 'Custom request',
+    });
+  };
+
+  const runPreset = async (preset: ApiPreset) => {
+    applyPreset(preset);
+    await executeRequest({
+      method: preset.method,
+      path: preset.path,
+      body: preset.body,
+      contentType: preset.contentType,
+      includeAuth: preset.includeAuth ?? true,
+      label: preset.label,
+      presetKey: preset.key,
+    });
+  };
+
+  const renderQuickSection = (
+    title: string,
+    description: string,
+    category: PresetCategory,
+    toneClasses: string
+  ) => {
+    const presets = getPresetsByCategory(category);
+
+    return (
+      <div className={`rounded-2xl border p-5 ${toneClasses}`}>
+        <div className="flex flex-col gap-1 mb-4">
+          <h3 className="text-lg font-semibold text-slate-900">{title}</h3>
+          <p className="text-sm text-slate-700">{description}</p>
+        </div>
+
+        <div className="grid grid-cols-1 lg:grid-cols-2 gap-3">
+          {presets.map((preset) => (
+            <div key={preset.key} className="rounded-xl border border-white/70 bg-white/80 p-4 shadow-sm">
+              <div className="flex items-start justify-between gap-3">
+                <div>
+                  <div className="flex items-center gap-2">
+                    <span className="text-xs font-semibold text-blue-600">{preset.method}</span>
+                    <span className="font-medium text-slate-900">{preset.label}</span>
+                  </div>
+                  <div className="text-xs text-slate-500 mt-1">{preset.path}</div>
+                </div>
+                <button
+                  type="button"
+                  onClick={() => void runPreset(preset)}
+                  disabled={loading}
+                  className="px-3 py-1.5 rounded-lg bg-slate-900 text-white text-sm font-medium hover:bg-slate-800 disabled:bg-slate-400 transition-colors"
+                >
+                  {loading && activePresetKey === preset.key ? '실행 중...' : '실행'}
+                </button>
+              </div>
+              <div className="text-sm text-slate-600 mt-3">{preset.description}</div>
+              <button
+                type="button"
+                onClick={() => applyPreset(preset)}
+                className="mt-3 text-xs font-medium text-slate-600 hover:text-slate-900"
+              >
+                요청 빌더에 채우기
+              </button>
+            </div>
+          ))}
+        </div>
+      </div>
+    );
+  };
+
+  return (
+    <section className="bg-white rounded-2xl shadow-lg border border-slate-200 p-6">
+      <div className="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
+        <div>
+          <h2 className="text-2xl font-semibold text-slate-900">Dev API Control</h2>
+          <p className="text-sm text-slate-600 mt-1">
+            `dev-console` 안에서 임의 API를 직접 호출하고, 외부 수집과 만료 처리까지 실행합니다.
+          </p>
+        </div>
+        <div className="flex flex-wrap gap-2 text-xs">
+          <span className="px-3 py-1.5 rounded-full bg-slate-100 text-slate-700">
+            Base URL: {apiBaseUrl}
+          </span>
+          <span
+            className={`px-3 py-1.5 rounded-full ${
+              token ? 'bg-emerald-100 text-emerald-700' : 'bg-amber-100 text-amber-700'
+            }`}
+          >
+            Token: {token ? 'loaded' : 'missing'}
+          </span>
+        </div>
+      </div>
+
+      <div className="mt-5 rounded-2xl border border-slate-200 bg-slate-50 px-4 py-4 text-sm text-slate-700">
+        외부 데이터 수집 버튼은 백엔드가 공개 API를 직접 호출한 뒤 서버 측 필터링을 적용해 저장합니다.
+        공연/행사 만료 버튼은 종료된 데이터를 비활성화하고, 약속 만료 버튼은 EXPIRED 상태 갱신을 즉시 수행합니다.
+      </div>
+
+      <div className="mt-6 space-y-4">
+        {renderQuickSection(
+          '외부 데이터 수집',
+          '도서관, 공연, 문화행사, 공원, 맛집 데이터를 수집하고 필터링 결과를 바로 확인합니다.',
+          'external-data',
+          'border-blue-200 bg-blue-50/70'
+        )}
+
+        {renderQuickSection(
+          '만료 및 보정 작업',
+          '종료 데이터 비활성화, 약속 만료 체크, 공개 상태 보정 같은 운영성 작업을 즉시 실행합니다.',
+          'maintenance',
+          'border-amber-200 bg-amber-50/70'
+        )}
+      </div>
+
+      <div className="mt-6">
+        <div className="text-sm font-medium text-slate-800 mb-2">빠른 프리셋</div>
+        <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-4 gap-3">
+          {API_PRESETS.map((preset) => (
+            <button
+              key={`${preset.method}-${preset.path}`}
+              type="button"
+              onClick={() => applyPreset(preset)}
+              className="text-left rounded-xl border border-slate-200 px-4 py-3 hover:border-blue-400 hover:bg-blue-50 transition-colors"
+            >
+              <div className="flex items-center gap-2 mb-1">
+                <span className="text-xs font-semibold text-blue-600">{preset.method}</span>
+                <span className="text-sm font-medium text-slate-900">{preset.label}</span>
+              </div>
+              <div className="text-xs text-slate-500 truncate">{preset.path}</div>
+              <div className="text-xs text-slate-600 mt-2">{preset.description}</div>
+            </button>
+          ))}
+        </div>
+      </div>
+
+      <div className="mt-6 grid grid-cols-1 xl:grid-cols-[180px_1fr] gap-4">
+        <div>
+          <label className="block text-sm font-medium text-slate-700 mb-2">Method</label>
+          <select
+            value={method}
+            onChange={(e) => setMethod(e.target.value as HttpMethod)}
+            className="w-full rounded-lg border border-slate-300 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500"
+          >
+            <option value="GET">GET</option>
+            <option value="POST">POST</option>
+            <option value="PUT">PUT</option>
+            <option value="PATCH">PATCH</option>
+            <option value="DELETE">DELETE</option>
+          </select>
+        </div>
+        <div>
+          <label className="block text-sm font-medium text-slate-700 mb-2">Path or URL</label>
+          <input
+            type="text"
+            value={path}
+            onChange={(e) => setPath(e.target.value)}
+            placeholder="/api/v1/users/me"
+            className="w-full rounded-lg border border-slate-300 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500"
+          />
+        </div>
+      </div>
+
+      <div className="mt-4 grid grid-cols-1 xl:grid-cols-[220px_1fr] gap-4">
+        <div>
+          <label className="block text-sm font-medium text-slate-700 mb-2">Content-Type</label>
+          <input
+            type="text"
+            value={contentType}
+            onChange={(e) => setContentType(e.target.value)}
+            placeholder="application/json"
+            className="w-full rounded-lg border border-slate-300 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500"
+          />
+        </div>
+        <div className="flex items-center gap-3 rounded-lg border border-slate-200 px-4 py-3 bg-slate-50">
+          <input
+            id="include-auth"
+            type="checkbox"
+            checked={includeAuth}
+            onChange={(e) => setIncludeAuth(e.target.checked)}
+            className="h-4 w-4 rounded border-slate-300 text-blue-600 focus:ring-blue-500"
+          />
+          <label htmlFor="include-auth" className="text-sm text-slate-700">
+            localStorage `token`을 Authorization 헤더에 포함
+          </label>
+        </div>
+      </div>
+
+      <div className="mt-4 grid grid-cols-1 xl:grid-cols-2 gap-4">
+        <div>
+          <label className="block text-sm font-medium text-slate-700 mb-2">
+            Extra Headers JSON
+          </label>
+          <textarea
+            value={customHeaders}
+            onChange={(e) => setCustomHeaders(e.target.value)}
+            rows={10}
+            placeholder={'{\n  "X-Debug": "true"\n}'}
+            className="w-full rounded-lg border border-slate-300 px-3 py-2 font-mono text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+          />
+        </div>
+        <div>
+          <label className="block text-sm font-medium text-slate-700 mb-2">Request Body</label>
+          <textarea
+            value={requestBody}
+            onChange={(e) => setRequestBody(e.target.value)}
+            rows={10}
+            placeholder={'{\n  "sample": true\n}'}
+            className="w-full rounded-lg border border-slate-300 px-3 py-2 font-mono text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+          />
+        </div>
+      </div>
+
+      <div className="mt-5 flex flex-wrap gap-3">
+        <button
+          type="button"
+          onClick={() => void handleSendRequest()}
+          disabled={loading}
+          className="px-5 py-2.5 rounded-lg bg-slate-900 text-white font-medium hover:bg-slate-800 disabled:bg-slate-400 transition-colors"
+        >
+          {loading && !activePresetKey ? '요청 중...' : 'API 호출'}
+        </button>
+        <button
+          type="button"
+          onClick={resetResponse}
+          className="px-5 py-2.5 rounded-lg border border-slate-300 text-slate-700 font-medium hover:bg-slate-50 transition-colors"
+        >
+          응답 초기화
+        </button>
+      </div>
+
+      {requestError && (
+        <div className="mt-5 rounded-xl border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
+          {requestError}
+        </div>
+      )}
+
+      {response && (
+        <div className="mt-6 space-y-4">
+          <div className="flex flex-col gap-3 rounded-2xl border border-slate-200 bg-slate-50 p-4">
+            <div className="flex flex-wrap items-center gap-3">
+              <span
+                className={`px-3 py-1 rounded-full border text-sm font-semibold ${getResponseTone(
+                  response.status
+                )}`}
+              >
+                {response.status} {response.statusText}
+              </span>
+              <span className="text-sm text-slate-600">{response.durationMs} ms</span>
+              <span className="text-sm font-medium text-slate-900">{response.requestLabel}</span>
+            </div>
+            <div className="text-xs text-slate-500">
+              {response.requestMethod} {response.requestUrl}
+            </div>
+          </div>
+
+          {metricSections.length > 0 && (
+            <div className="grid grid-cols-1 xl:grid-cols-3 gap-4">
+              {metricSections.map((section) => (
+                <div key={section.title} className="rounded-2xl border border-slate-200 bg-white p-4">
+                  <div className="text-sm font-semibold text-slate-900 mb-3">{section.title}</div>
+                  <div className="grid grid-cols-2 gap-3">
+                    {section.metrics.map((metric) => (
+                      <div key={`${section.title}-${metric.label}`} className="rounded-xl bg-slate-50 p-3">
+                        <div className="text-xs text-slate-500">{metric.label}</div>
+                        <div className="text-xl font-semibold text-slate-900">{metric.value}</div>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+
+          {distributionSections.length > 0 && (
+            <div className="grid grid-cols-1 xl:grid-cols-2 gap-4">
+              {distributionSections.map((section) => (
+                <div key={section.title} className="rounded-2xl border border-slate-200 bg-white p-4">
+                  <div className="text-sm font-semibold text-slate-900 mb-3">{section.title}</div>
+                  <div className="space-y-2">
+                    {section.entries.map((entry) => (
+                      <div
+                        key={`${section.title}-${entry.label}`}
+                        className="flex items-center justify-between rounded-lg bg-slate-50 px-3 py-2 text-sm"
+                      >
+                        <span className="text-slate-600">{entry.label}</span>
+                        <span className="font-medium text-slate-900">{entry.value}</span>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+
+          <div className="grid grid-cols-1 xl:grid-cols-2 gap-4">
+            <div>
+              <div className="text-sm font-medium text-slate-700 mb-2">Response Headers</div>
+              <pre className="rounded-xl bg-slate-950 text-slate-100 p-4 text-xs overflow-x-auto min-h-[240px]">
+                {JSON.stringify(response.headers, null, 2)}
+              </pre>
+            </div>
+            <div>
+              <div className="text-sm font-medium text-slate-700 mb-2">Response Body</div>
+              <pre className="rounded-xl bg-slate-950 text-slate-100 p-4 text-xs overflow-x-auto min-h-[240px]">
+                {formatResponseBody(response.body)}
+              </pre>
+            </div>
+          </div>
+        </div>
+      )}
+    </section>
+  );
+};
+
+export default DevApiControlPanel;

--- a/frontend/src/components/FeaturedCard.tsx
+++ b/frontend/src/components/FeaturedCard.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { Appointment, AppointmentStatus } from '../types/appointment';
 import { differenceInHours, differenceInMinutes } from 'date-fns';
+import { getAppointmentNavigationPath } from '../utils/appointmentNavigation';
 
 interface FeaturedCardProps {
   appointment: Appointment;
@@ -55,7 +56,7 @@ const FeaturedCard: React.FC<FeaturedCardProps> = ({
 
   const handleClick = () => {
     // 약속 상세 화면으로 이동 (미션 상세)
-    navigate(`/mission/${appointment.id}`);
+    navigate(getAppointmentNavigationPath(appointment));
   };
 
   const getStatusText = (status: AppointmentStatus) => {

--- a/frontend/src/components/SmartActionModal.tsx
+++ b/frontend/src/components/SmartActionModal.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { getMyAppointments } from '../api/appointmentApi';
 import { Appointment, AppointmentStatus } from '../types/appointment';
+import { getAppointmentNavigationPath } from '../utils/appointmentNavigation';
 
 interface SmartActionModalProps {
   onClose: () => void;
@@ -47,7 +48,7 @@ const SmartActionModal = ({ onClose }: SmartActionModalProps) => {
   const handleContinue = () => {
     if (activeAppointment) {
       // 진행 중인 약속의 미션 상세로 이동
-      navigate(`/mission/${activeAppointment.id}`);
+      navigate(getAppointmentNavigationPath(activeAppointment));
       onClose();
     }
   };

--- a/frontend/src/pages/Appointments.tsx
+++ b/frontend/src/pages/Appointments.tsx
@@ -15,6 +15,7 @@ import { formatDateTime } from '../utils/dateUtils';
 import FeaturedCard from '../components/FeaturedCard';
 import { MapPin, Trash2 } from 'lucide-react';
 import { showToast } from '../utils/toast';
+import { getAppointmentNavigationPath } from '../utils/appointmentNavigation';
 
 const Appointments = () => {
   const navigate = useNavigate();
@@ -288,8 +289,9 @@ const Appointments = () => {
                         className="card p-0 overflow-hidden relative group cursor-pointer"
                         onClick={() => {
                           const isArchived = apt.status === AppointmentStatus.COMPLETED ||
-                                           apt.status === AppointmentStatus.CANCELLED;
-                          navigate(isArchived ? `/archived/${apt.id}` : `/mission/${apt.id}`);
+                                           apt.status === AppointmentStatus.CANCELLED ||
+                                           apt.status === AppointmentStatus.EXPIRED;
+                          navigate(isArchived ? `/archived/${apt.id}` : getAppointmentNavigationPath(apt));
                         }}
                       >
                         {/* 썸네일 */}
@@ -335,6 +337,9 @@ const Appointments = () => {
                             )}
                             {apt.status === AppointmentStatus.CANCELLED && (
                               <span className="bg-gray-500/90 text-white text-[10px] px-2 py-1 rounded-full font-bold">취소됨</span>
+                            )}
+                            {apt.status === AppointmentStatus.EXPIRED && (
+                              <span className="bg-amber-500/90 text-white text-[10px] px-2 py-1 rounded-full font-bold">만료</span>
                             )}
                           </div>
                         </div>

--- a/frontend/src/pages/ArchivedAppointmentDetail.tsx
+++ b/frontend/src/pages/ArchivedAppointmentDetail.tsx
@@ -50,6 +50,7 @@ function ArchivedAppointmentDetail() {
   }
 
   const isCompleted = appointment.status === AppointmentStatus.COMPLETED;
+  const isExpired = appointment.status === AppointmentStatus.EXPIRED;
   // isCancelled은 향후 취소 상태 UI 표시에 사용 예정
   const _isCancelled = appointment.status === AppointmentStatus.CANCELLED;
   void _isCancelled; // 미사용 경고 방지
@@ -85,11 +86,13 @@ function ArchivedAppointmentDetail() {
             className={`inline-flex items-center gap-2 px-6 py-3 rounded-full font-bold text-sm ${
               isCompleted
                 ? 'bg-green-500/20 text-green-400 border-2 border-green-500/30'
+                : isExpired
+                ? 'bg-amber-500/20 text-amber-300 border-2 border-amber-500/30'
                 : 'bg-gray-500/20 text-gray-400 border-2 border-gray-500/30'
             }`}
           >
-            <span className="text-lg">{isCompleted ? '✓' : '×'}</span>
-            <span>{isCompleted ? '완료된 약속' : '취소된 약속'}</span>
+            <span className="text-lg">{isCompleted ? '✓' : isExpired ? '⏰' : '×'}</span>
+            <span>{isCompleted ? '완료된 약속' : isExpired ? '만료된 약속' : '취소된 약속'}</span>
           </div>
         </motion.div>
 
@@ -240,6 +243,8 @@ function ArchivedAppointmentDetail() {
           <p className="text-text-gray-dark text-xs text-center">
             {isCompleted
               ? '소중한 추억을 간직하고 있어요'
+              : isExpired
+              ? '기한이 지나 이어서 진행할 수 없는 약속이에요.'
               : '다음에는 꼭 함께 할 거예요'}
           </p>
         </motion.div>

--- a/frontend/src/pages/ChatAppointment.tsx
+++ b/frontend/src/pages/ChatAppointment.tsx
@@ -485,3 +485,6 @@ const ChatAppointment = () => {
 };
 
 export default ChatAppointment;
+
+
+

--- a/frontend/src/pages/DevConsole.tsx
+++ b/frontend/src/pages/DevConsole.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import axios from 'axios';
 import { adminTimeTravel } from '../api/appointmentApi';
 import { showToast } from '../utils/toast';
+import DevApiControlPanel from '../components/DevApiControlPanel';
 import LocationSelectbox from '../components/LocationSelectbox';
 import type { LocationSelection } from '../components/LocationSelectbox';
 import { ALL_HOTSPOTS } from '../data/seoulDistricts';
@@ -9,8 +10,9 @@ import { ALL_HOTSPOTS } from '../data/seoulDistricts';
 // API Types
 type Weather = 'SUNNY' | 'RAIN' | 'SNOW' | 'CLOUDY';
 type AirQuality = 'GOOD' | 'BAD' | 'WORST';
-type Congestion = 'LOW' | 'MEDIUM' | 'HIGH' | 'NORMAL'; // NORMAL 추가 (서울시 API 기본값)
+type Congestion = 'LOW' | 'NORMAL' | 'HIGH';
 type MissionCategory = 'FOOD' | 'ACTIVITY' | 'RELAX' | 'CULTURE';
+type UserConstraint = 'NO_ALCOHOL' | 'HATE_WALKING' | 'NO_SPORTS' | 'INDOOR_ONLY';
 
 interface SimulationRequest {
   targetDateTime: string;
@@ -22,6 +24,8 @@ interface SimulationRequest {
   airQuality: AirQuality;
   congestion: Congestion;
   userMbti: string;
+  userId?: number;
+  userTags?: string;
   forcedCategory?: MissionCategory;
 }
 
@@ -68,10 +72,36 @@ interface MissionInfo {
   guide: string;
 }
 
+interface SimulationReasonInfo {
+  code: string;
+  beforeCount: number;
+  afterCount: number;
+  detail: string | null;
+}
+
+interface SimulationSelectionInfo {
+  type: string;
+  id: number | null;
+  name: string | null;
+  category: string | null;
+  detail?: string | null;
+}
+
+interface SimulationStageInfo {
+  code: string;
+  label: string;
+  targetType: string;
+  beforeCount: number;
+  afterCount: number;
+  reasons: SimulationReasonInfo[];
+  selections: SimulationSelectionInfo[];
+}
+
 interface SimulationResponse {
   mission: MissionInfo | null;
   place: PlaceInfo | null;
   debugLogs: string[];
+  stages: SimulationStageInfo[];
   totalMissionCandidates: number;
   filteredMissionCandidates: number;
   totalPlaceCandidates: number;
@@ -89,6 +119,45 @@ const WEATHER_OPTIONS: { value: Weather; icon: string; label: string }[] = [
   { value: 'SNOW', icon: '❄️', label: '눈' },
   { value: 'CLOUDY', icon: '☁️', label: '흐림' },
 ];
+
+const CONGESTION_OPTIONS: { value: Congestion; label: string }[] = [
+  { value: 'LOW', label: 'Low' },
+  { value: 'NORMAL', label: 'Normal' },
+  { value: 'HIGH', label: 'High' },
+];
+
+const USER_CONSTRAINT_OPTIONS: {
+  value: UserConstraint;
+  label: string;
+  description: string;
+}[] = [
+  {
+    value: 'NO_ALCOHOL',
+    label: 'NO_ALCOHOL',
+    description: 'Exclude alcohol-only missions and places.',
+  },
+  {
+    value: 'HATE_WALKING',
+    label: 'HATE_WALKING',
+    description: 'Exclude high-activity or walking-heavy options.',
+  },
+  {
+    value: 'NO_SPORTS',
+    label: 'NO_SPORTS',
+    description: 'Exclude sports-required options.',
+  },
+  {
+    value: 'INDOOR_ONLY',
+    label: 'INDOOR_ONLY',
+    description: 'Exclude outdoor-required options.',
+  },
+];
+
+const getStageTone = (targetType: string) => {
+  if (targetType === 'MISSION') return 'bg-blue-100 text-blue-700';
+  if (targetType === 'PLACE') return 'bg-emerald-100 text-emerald-700';
+  return 'bg-amber-100 text-amber-700';
+};
 
 const DevConsole = () => {
   const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || 'http://localhost:8080';
@@ -110,8 +179,19 @@ const DevConsole = () => {
   const [airQuality, setAirQuality] = useState<AirQuality>('GOOD');
   const [congestion, setCongestion] = useState<Congestion>('NORMAL');
   const [userMbti, setUserMbti] = useState<'I' | 'E'>('I');
+  const [preferenceUserId, setPreferenceUserId] = useState<string>('');
+  const [userTags, setUserTags] = useState<UserConstraint[]>([]);
+  const [appliedUserTags, setAppliedUserTags] = useState<UserConstraint[]>([]);
   const [forcedCategory, setForcedCategory] = useState<MissionCategory | ''>('');
   const [timeTravelId, setTimeTravelId] = useState<string>('');
+
+  const toggleUserConstraint = (constraint: UserConstraint) => {
+    setUserTags((current) =>
+      current.includes(constraint)
+        ? current.filter((value) => value !== constraint)
+        : [...current, constraint]
+    );
+  };
 
   // Random Scenario Generator
   const generateRandomScenario = () => {
@@ -141,11 +221,16 @@ const DevConsole = () => {
     setAirQuality(airQualities[Math.floor(Math.random() * airQualities.length)]);
 
     // Random congestion
-    const congestions: Congestion[] = ['LOW', 'NORMAL', 'MEDIUM', 'HIGH'];
+    const congestions = CONGESTION_OPTIONS.map((option) => option.value);
     setCongestion(congestions[Math.floor(Math.random() * congestions.length)]);
 
     // Random MBTI
     setUserMbti(Math.random() > 0.5 ? 'I' : 'E');
+
+    // Random user constraints
+    setUserTags(
+      USER_CONSTRAINT_OPTIONS.filter(() => Math.random() > 0.65).map((option) => option.value)
+    );
 
     // Random category (optional)
     const categories: (MissionCategory | '')[] = ['', 'FOOD', 'ACTIVITY', 'RELAX', 'CULTURE'];
@@ -158,6 +243,8 @@ const DevConsole = () => {
     setError(null);
     setResult(null);
 
+    const submittedUserTags = [...userTags];
+
     const request: SimulationRequest = {
       targetDateTime,
       latitude,
@@ -168,8 +255,11 @@ const DevConsole = () => {
       airQuality,
       congestion,
       userMbti,
+      ...(preferenceUserId.trim() && { userId: Number(preferenceUserId) }),
+      ...(submittedUserTags.length > 0 && { userTags: submittedUserTags.join(',') }),
       ...(forcedCategory && { forcedCategory }),
     };
+    setAppliedUserTags(submittedUserTags);
 
     try {
       const response = await axios.post<SimulationResponse>(
@@ -178,7 +268,12 @@ const DevConsole = () => {
       );
       setResult(response.data);
     } catch (err: any) {
-      setError(err.response?.data?.message || err.message || '시뮬레이션 실행 실패');
+      setError(
+        err.response?.data?.message ||
+          err.response?.data?.debugLogs?.[0] ||
+          err.message ||
+          '시뮬레이션 실행 실패'
+      );
     } finally {
       setLoading(false);
     }
@@ -343,20 +438,18 @@ const DevConsole = () => {
               {/* Congestion */}
               <div>
                 <label className="block text-sm font-medium text-gray-700 mb-2">혼잡도</label>
-                <div className="grid grid-cols-4 gap-2">
-                  {(['LOW', 'NORMAL', 'MEDIUM', 'HIGH'] as Congestion[]).map((value) => (
+                <div className="grid grid-cols-3 gap-2">
+                  {CONGESTION_OPTIONS.map((option) => (
                     <button
-                      key={value}
-                      onClick={() => setCongestion(value)}
+                      key={option.value}
+                      onClick={() => setCongestion(option.value)}
                       className={`px-3 py-2 rounded-md border-2 transition-all ${
-                        congestion === value
+                        congestion === option.value
                           ? 'border-blue-500 bg-blue-50'
                           : 'border-gray-300 hover:border-blue-300'
                       }`}
                     >
-                      {value === 'LOW' ? '🤗 한적함' :
-                       value === 'NORMAL' ? '😊 여유' :
-                       value === 'MEDIUM' ? '🙂 보통' : '😵 터짐'}
+                      {option.label}
                     </button>
                   ))}
                 </div>
@@ -395,6 +488,53 @@ const DevConsole = () => {
                     <div className="text-lg font-bold">E</div>
                     <div className="text-xs text-gray-600">외향형</div>
                   </button>
+                </div>
+              </div>
+
+              <div className="mb-4">
+                <label className="block text-sm font-medium text-gray-700 mb-2">
+                  Preference User ID
+                </label>
+                <input
+                  type="number"
+                  min="1"
+                  placeholder="Optional userId for saved/liked/completed weights"
+                  value={preferenceUserId}
+                  onChange={(e) => setPreferenceUserId(e.target.value)}
+                  className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+                />
+                <div className="mt-2 text-xs text-gray-500">
+                  Leave blank to use neutral mission weights. Set a user ID to reuse saved, liked,
+                  completed, and cancelled preference signals from real recommendations.
+                </div>
+              </div>
+
+              <div className="mb-4">
+                <label className="block text-sm font-medium text-gray-700 mb-2">
+                  User Constraints
+                </label>
+                <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+                  {USER_CONSTRAINT_OPTIONS.map((option) => {
+                    const isActive = userTags.includes(option.value);
+                    return (
+                      <button
+                        key={option.value}
+                        type="button"
+                        onClick={() => toggleUserConstraint(option.value)}
+                        className={`rounded-md border-2 px-3 py-3 text-left transition-all ${
+                          isActive
+                            ? 'border-blue-500 bg-blue-50'
+                            : 'border-gray-300 hover:border-blue-300'
+                        }`}
+                      >
+                        <div className="text-sm font-semibold text-gray-900">{option.label}</div>
+                        <div className="mt-1 text-xs text-gray-600">{option.description}</div>
+                      </button>
+                    );
+                  })}
+                </div>
+                <div className="mt-2 text-xs text-gray-500">
+                  Uses the same backend tag-conflict rules as appointment recommendations.
                 </div>
               </div>
 
@@ -483,6 +623,35 @@ const DevConsole = () => {
             {/* Result Display */}
             {result && (
               <>
+                <section className="bg-white rounded-lg shadow p-6">
+                  <div className="flex items-center justify-between gap-3">
+                    <h3 className="text-lg font-semibold text-gray-900">Applied User Constraints</h3>
+                    <span className="rounded-full bg-slate-100 px-3 py-1 text-xs font-semibold text-slate-700">
+                      {appliedUserTags.length} active
+                    </span>
+                  </div>
+                  <div className="mt-4 flex flex-wrap gap-2">
+                    {appliedUserTags.length > 0 ? (
+                      appliedUserTags.map((tag) => (
+                        <span
+                          key={tag}
+                          className="rounded-full border border-blue-200 bg-blue-50 px-3 py-1 text-xs font-semibold text-blue-700"
+                        >
+                          {tag}
+                        </span>
+                      ))
+                    ) : (
+                      <span className="rounded-full border border-gray-200 bg-gray-50 px-3 py-1 text-xs font-semibold text-gray-500">
+                        None
+                      </span>
+                    )}
+                  </div>
+                  <p className="mt-3 text-xs text-gray-500">
+                    These constraints feed the simulation request and the shared backend tag-conflict
+                    rule set.
+                  </p>
+                </section>
+
                 {/* Mission Card */}
                 {result.mission && (
                   <section className="bg-white rounded-lg shadow p-6">
@@ -618,6 +787,101 @@ const DevConsole = () => {
                     </div>
                   </div>
                 </section>
+
+                {result.stages && result.stages.length > 0 && (
+                  <section className="bg-white rounded-lg shadow p-6 border-2 border-slate-200">
+                    <div className="mb-4">
+                      <h3 className="text-lg font-semibold text-gray-900">Structured Debug Trace</h3>
+                      <p className="text-xs text-gray-500 mt-1">
+                        Stage counts and reason codes for the simulation pipeline.
+                      </p>
+                    </div>
+                    <div className="space-y-4">
+                      {result.stages.map((stage) => (
+                        <div
+                          key={stage.code}
+                          className="rounded-xl border border-gray-200 p-4 bg-slate-50/50"
+                        >
+                          <div className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
+                            <div>
+                              <div className="flex flex-wrap items-center gap-2">
+                                <span
+                                  className={`px-2 py-0.5 rounded-full text-[11px] font-semibold ${getStageTone(stage.targetType)}`}
+                                >
+                                  {stage.targetType}
+                                </span>
+                                <div className="font-semibold text-gray-900">{stage.label}</div>
+                              </div>
+                              <div className="text-[11px] text-gray-500 font-mono mt-1">
+                                {stage.code}
+                              </div>
+                            </div>
+                            <div className="grid grid-cols-2 gap-2 text-sm min-w-[180px]">
+                              <div className="rounded-lg bg-white border border-gray-200 px-3 py-2">
+                                <div className="text-[11px] text-gray-500">Before</div>
+                                <div className="font-semibold text-gray-900">{stage.beforeCount}</div>
+                              </div>
+                              <div className="rounded-lg bg-white border border-gray-200 px-3 py-2">
+                                <div className="text-[11px] text-gray-500">After</div>
+                                <div className="font-semibold text-gray-900">{stage.afterCount}</div>
+                              </div>
+                            </div>
+                          </div>
+
+                          {stage.reasons.length > 0 && (
+                            <div className="mt-4 overflow-x-auto">
+                              <table className="min-w-full text-xs">
+                                <thead>
+                                  <tr className="text-left text-gray-500 border-b border-gray-200">
+                                    <th className="py-2 pr-4 font-medium">Reason</th>
+                                    <th className="py-2 pr-4 font-medium">Before</th>
+                                    <th className="py-2 pr-4 font-medium">After</th>
+                                    <th className="py-2 font-medium">Detail</th>
+                                  </tr>
+                                </thead>
+                                <tbody>
+                                  {stage.reasons.map((reason) => (
+                                    <tr
+                                      key={`${stage.code}-${reason.code}-${reason.beforeCount}-${reason.afterCount}`}
+                                      className="border-b border-gray-100 last:border-b-0"
+                                    >
+                                      <td className="py-2 pr-4 font-mono text-[11px] text-gray-700">
+                                        {reason.code}
+                                      </td>
+                                      <td className="py-2 pr-4 text-gray-700">{reason.beforeCount}</td>
+                                      <td className="py-2 pr-4 text-gray-700">{reason.afterCount}</td>
+                                      <td className="py-2 text-gray-600">{reason.detail || '-'}</td>
+                                    </tr>
+                                  ))}
+                                </tbody>
+                              </table>
+                            </div>
+                          )}
+
+                          {stage.selections.length > 0 && (
+                            <div className="mt-4 flex flex-wrap gap-2">
+                              {stage.selections.map((selection) => (
+                                <div
+                                  key={`${stage.code}-${selection.type}-${selection.id ?? 'none'}`}
+                                  className="rounded-lg bg-white border border-gray-200 px-3 py-2 text-xs"
+                                >
+                                  <div className="font-semibold text-gray-700">{selection.type}</div>
+                                  <div className="text-gray-900">{selection.name || 'N/A'}</div>
+                                  <div className="text-gray-500">{selection.category || 'N/A'}</div>
+                                  {selection.detail && (
+                                    <div className="mt-1 text-[11px] text-gray-500">
+                                      {selection.detail}
+                                    </div>
+                                  )}
+                                </div>
+                              ))}
+                            </div>
+                          )}
+                        </div>
+                      ))}
+                    </div>
+                  </section>
+                )}
 
                 {/* Integrated View: Mission + Place + Detail */}
                 {result.mission && (
@@ -860,7 +1124,7 @@ const DevConsole = () => {
                 {/* Debug Logs (Terminal Style) */}
                 <section className="bg-gray-900 rounded-lg shadow p-6">
                   <h3 className="text-lg font-semibold text-white mb-3 flex items-center gap-2">
-                    🖥️ Debug Logs
+                    🖥️ Legacy Debug Logs
                   </h3>
                   <div className="bg-black rounded-lg p-4 font-mono text-sm max-h-96 overflow-y-auto">
                     {result.debugLogs.map((log, index) => (
@@ -895,6 +1159,10 @@ const DevConsole = () => {
               </div>
             )}
           </div>
+        </div>
+
+        <div className="mt-8">
+          <DevApiControlPanel apiBaseUrl={API_BASE_URL} />
         </div>
       </div>
     </div>

--- a/frontend/src/pages/FeedPage.tsx
+++ b/frontend/src/pages/FeedPage.tsx
@@ -12,6 +12,7 @@ import { useInfiniteScroll } from '../hooks/useInfiniteScroll';
 import { showToast } from '../utils/toast';
 import { Comment, createComment, getComments, deleteComment } from '../api/commentApi';
 import { Appointment } from '../types/appointment';
+import { getAppointmentNavigationPath, needsAppointmentSelection } from '../utils/appointmentNavigation';
 
 const FeedPage = () => {
   const navigate = useNavigate();
@@ -42,8 +43,11 @@ const FeedPage = () => {
         console.log('📋 미완료 약속 발견:', appointment);
         setPendingAppointment(appointment);
         localStorage.setItem('appointmentId', String(appointment.id));
+      } else {
+        setPendingAppointment(null);
       }
     } catch {
+      setPendingAppointment(null);
       console.log('ℹ️ 진행 중인 약속 없음');
     }
   };
@@ -52,20 +56,7 @@ const FeedPage = () => {
   const handleContinueAppointment = () => {
     if (!pendingAppointment) return;
 
-    // 장소가 없으면 위치 설정으로
-    if (!pendingAppointment.placeName) {
-      navigate('/location');
-      return;
-    }
-
-    // 미션이 없으면 미션 선택으로
-    if (!pendingAppointment.missionTitle) {
-      navigate('/missions');
-      return;
-    }
-
-    // 모두 있으면 미션 상세로
-    navigate(`/mission/${pendingAppointment.id}`);
+    navigate(getAppointmentNavigationPath(pendingAppointment));
   };
 
   const loadFeeds = async (pageNum: number = page) => {
@@ -326,10 +317,10 @@ const FeedPage = () => {
                 onClick={handleContinueAppointment}
                 className="flex-shrink-0 bg-electric-lime text-deep-charcoal px-4 py-2 rounded-full font-bold text-sm hover:bg-electric-lime/90 transition-colors"
               >
-                {!pendingAppointment.placeName
-                  ? '장소 선택'
-                  : !pendingAppointment.missionTitle
-                  ? '미션 선택'
+                {needsAppointmentSelection(pendingAppointment)
+                  ? '선택 이어가기'
+                  : !pendingAppointment.placeName || !pendingAppointment.missionTitle
+                  ? '이어서 진행'
                   : '확인하기'}
               </button>
             </div>

--- a/frontend/src/pages/MissionDetail.tsx
+++ b/frontend/src/pages/MissionDetail.tsx
@@ -2,12 +2,13 @@ import { useEffect, useState, useRef } from 'react';
 import { useParams, useNavigate, useLocation } from 'react-router-dom';
 import { motion, AnimatePresence } from 'framer-motion';
 import { getAppointmentDetail, completeAppointment, markAsArrived, swapMission, deleteAppointment } from '../api/appointmentApi';
-import { Appointment } from '../types/appointment';
+import { Appointment, AppointmentStatus } from '../types/appointment';
 import { PlanB } from '../types/mission';
 import { supabase } from '../lib/supabaseClient';
 import MissionReview from '../components/MissionReview';
 import { showToast } from '../utils/toast';
 import { Trash2 } from 'lucide-react';
+import { getAppointmentNavigationPath } from '../utils/appointmentNavigation';
 
 // 가이드 스텝 인터페이스
 interface GuideStep {
@@ -101,11 +102,9 @@ function MissionDetail() {
 
       try {
         const data = await getAppointmentDetail(Number(appointmentId));
-
-        // 장소가 없는 약속인 경우 -> 온보딩 플로우로 리다이렉트
-        if (!data.placeName) {
-          console.log('📍 장소가 없는 약속 -> 온보딩 플로우로 이동');
-          navigate('/location', { replace: true });
+        const targetPath = getAppointmentNavigationPath(data);
+        if (targetPath !== `/mission/${data.id}`) {
+          navigate(targetPath, { replace: true });
           return;
         }
 
@@ -114,8 +113,8 @@ function MissionDetail() {
         console.error('약속 로딩 실패:', err);
         // 약속을 찾을 수 없는 경우 (404, 400 등) -> 로컬 스토리지 정리 및 이동
         localStorage.removeItem('appointmentId');
-        alert('약속 정보를 찾을 수 없어. 다시 시작할게.');
-        navigate('/location', { replace: true });
+        alert('약속 정보를 찾을 수 없어. 피드로 돌아갈게.');
+        navigate('/feed', { replace: true });
       } finally {
         setLoading(false);
       }
@@ -465,6 +464,10 @@ function MissionDetail() {
   const backgroundImage = unlocked
     ? appointment.placeImageUrl || appointment.missionImageUrl
     : appointment.missionImageUrl;
+  const appointmentTitle = appointment.missionTitle || (appointment.placeName ? `${appointment.placeName}에서 만나요!` : '약속 준비 중');
+  const appointmentPlaceLabel = appointment.placeName || '장소 정보 준비 중';
+  const appointmentPlaceAddress = appointment.placeAddress || '상세 위치가 아직 준비 중이에요.';
+  const hasPlaceInfo = Boolean(appointment.placeName);
 
   // 서버 데이터 기반으로 도착 여부 판단
   const isArrived = appointment.status === 'ARRIVED' ||
@@ -473,8 +476,8 @@ function MissionDetail() {
 
   // Timeline Step 상태 계산
   const isStep1Complete = true; // 준비는 항상 활성화
-  const isStep2Complete = isArrived;
-  const isStep3Unlocked = isArrived;
+  const isStep2Complete = hasPlaceInfo ? isArrived : unlocked;
+  const isStep3Unlocked = hasPlaceInfo ? isArrived : unlocked;
 
   return (
     <div className="min-h-screen bg-deep-charcoal flex flex-col pb-24">
@@ -521,7 +524,7 @@ function MissionDetail() {
           className="space-y-4"
         >
           <h1 className="text-off-white text-3xl sm:text-4xl font-extra-bold tracking-tight">
-            {appointment.missionTitle || '미션 미선택'}
+            {appointmentTitle}
           </h1>
           <p className="text-text-gray text-lg">
             {new Date(appointment.scheduledAt).toLocaleDateString('ko-KR', {
@@ -551,7 +554,7 @@ function MissionDetail() {
           >
             <img
               src={backgroundImage}
-              alt={appointment.missionTitle || '미션'}
+              alt={appointmentTitle}
               className="w-full h-full object-cover brightness-75"
             />
           </motion.div>
@@ -646,64 +649,75 @@ function MissionDetail() {
                 {unlocked ? (
                   <>
                     <p className="text-text-gray text-lg font-semibold">
-                      {appointment.placeName || '장소 정보 없음'}
+                      {appointmentPlaceLabel}
                     </p>
                     <p className="text-text-gray-dark text-sm">
-                      {appointment.placeAddress || '주소 정보 없음'}
+                      {appointmentPlaceAddress}
                     </p>
 
-                    {/* 지도 버튼 - 카카오맵 통일 */}
-                    <div className="w-full">
-                      <a
-                        href={
-                          appointment.latitude && appointment.longitude
-                            ? `https://map.kakao.com/link/to/${encodeURIComponent(appointment.placeName || '목적지')},${appointment.latitude},${appointment.longitude}`
-                            : `https://map.kakao.com/link/search/${encodeURIComponent(appointment.placeName || '')}`
-                        }
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        className="btn-primary flex items-center justify-center gap-2 text-sm w-full"
-                      >
-                        🗺️ 카카오맵으로 길찾기
-                      </a>
-                    </div>
+                    {hasPlaceInfo ? (
+                      <>
+                        {/* 지도 버튼 - 카카오맵 통일 */}
+                        <div className="w-full">
+                          <a
+                            href={
+                              appointment.latitude && appointment.longitude
+                                ? `https://map.kakao.com/link/to/${encodeURIComponent(appointment.placeName || '목적지')},${appointment.latitude},${appointment.longitude}`
+                                : `https://map.kakao.com/link/search/${encodeURIComponent(appointment.placeName || '')}`
+                            }
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="btn-primary flex items-center justify-center gap-2 text-sm w-full"
+                          >
+                            🗺️ 카카오맵으로 길찾기
+                          </a>
+                        </div>
 
-                    {/* 도착 인증 버튼 */}
-                    {!isArrived && (
-                      <button
-                        onClick={handleArrivalCheck}
-                        disabled={isArrivingLoading}
-                        className="btn-outline w-full mt-4 disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-2"
-                      >
-                        {isArrivingLoading ? (
-                          <>
-                            <svg className="animate-spin h-5 w-5" viewBox="0 0 24 24">
-                              <circle
-                                className="opacity-25"
-                                cx="12"
-                                cy="12"
-                                r="10"
-                                stroke="currentColor"
-                                strokeWidth="4"
-                                fill="none"
-                              />
-                              <path
-                                className="opacity-75"
-                                fill="currentColor"
-                                d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
-                              />
-                            </svg>
-                            <span>인증 중...</span>
-                          </>
-                        ) : (
-                          <>📍 도착 인증하기</>
+                        {/* 도착 인증 버튼 */}
+                        {!isArrived && (
+                          <button
+                            onClick={handleArrivalCheck}
+                            disabled={isArrivingLoading}
+                            className="btn-outline w-full mt-4 disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-2"
+                          >
+                            {isArrivingLoading ? (
+                              <>
+                                <svg className="animate-spin h-5 w-5" viewBox="0 0 24 24">
+                                  <circle
+                                    className="opacity-25"
+                                    cx="12"
+                                    cy="12"
+                                    r="10"
+                                    stroke="currentColor"
+                                    strokeWidth="4"
+                                    fill="none"
+                                  />
+                                  <path
+                                    className="opacity-75"
+                                    fill="currentColor"
+                                    d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+                                  />
+                                </svg>
+                                <span>인증 중...</span>
+                              </>
+                            ) : (
+                              <>📍 도착 인증하기</>
+                            )}
+                          </button>
                         )}
-                      </button>
-                    )}
 
-                    {isArrived && (
-                      <div className="bg-electric-lime/10 border border-electric-lime/30 rounded-solotion p-3 text-center">
-                        <p className="text-electric-lime font-bold">✅ 도착 인증 완료!</p>
+                        {isArrived && (
+                          <div className="bg-electric-lime/10 border border-electric-lime/30 rounded-solotion p-3 text-center">
+                            <p className="text-electric-lime font-bold">✅ 도착 인증 완료!</p>
+                          </div>
+                        )}
+                      </>
+                    ) : (
+                      <div className="rounded-solotion border border-charcoal-lighter bg-charcoal-lighter/40 p-4">
+                        <p className="text-off-white font-semibold mb-2">기존 약속을 이어서 불러왔어요.</p>
+                        <p className="text-text-gray text-sm leading-relaxed">
+                          장소 정보가 아직 확정되지 않았어도 약속 상세는 계속 확인할 수 있어요.
+                        </p>
                       </div>
                     )}
                   </>
@@ -723,10 +737,10 @@ function MissionDetail() {
                             }}
                           >
                             <p className="text-text-gray text-lg font-semibold select-none">
-                              {appointment.placeName || '장소 정보 없음'}
+                              {appointmentPlaceLabel}
                             </p>
                             <p className="text-text-gray-dark text-sm select-none">
-                              {appointment.placeAddress || '주소 정보 없음'}
+                              {appointmentPlaceAddress}
                             </p>
                           </div>
 

--- a/frontend/src/pages/OAuthCallback.tsx
+++ b/frontend/src/pages/OAuthCallback.tsx
@@ -2,6 +2,7 @@ import { useEffect } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 import { getMyInfo } from '../api/userApi';
 import { getNextAppointment } from '../api/appointmentApi';
+import { getAppointmentNavigationPath } from '../utils/appointmentNavigation';
 
 function OAuthCallback() {
   const navigate = useNavigate();
@@ -33,7 +34,7 @@ function OAuthCallback() {
               console.log('🎯 진행 중인 약속 발견! -> 약속 상세로 이동:', nextAppointment.id);
               localStorage.setItem('appointmentId', String(nextAppointment.id));
               localStorage.setItem('onboarding_complete', 'true');
-              navigate(`/mission/${nextAppointment.id}`, { replace: true });
+              navigate(getAppointmentNavigationPath(nextAppointment), { replace: true });
               return;
             }
           } catch (appointmentError) {

--- a/frontend/src/routes/RouteGuards.tsx
+++ b/frontend/src/routes/RouteGuards.tsx
@@ -2,6 +2,7 @@ import { ReactNode, useEffect, useState } from 'react';
 import { Navigate, useParams } from 'react-router-dom';
 import { getMyInfo } from '../api/userApi';
 import { getNextAppointment } from '../api/appointmentApi';
+import { getAppointmentNavigationPath } from '../utils/appointmentNavigation';
 
 // ID 유효성 검사 헬퍼 함수
 const isValidId = (id: string | null): boolean => {
@@ -22,12 +23,12 @@ export const RequireNewUser = ({ children }: { children: ReactNode }) => {
   useEffect(() => {
     const checkStatus = async () => {
       const onboardingComplete = localStorage.getItem('onboarding_complete');
-      const appointmentId = localStorage.getItem('appointmentId');
+      const nextAppointment = await getNextAppointment();
 
-      // 1. 약속이 있는 경우 -> 미션 상세 페이지로
-      if (isValidId(appointmentId)) {
-        console.warn('⚠️ [RequireNewUser] 약속이 있는 유저 -> /mission으로 리다이렉트');
-        setShouldRedirect(`/mission/${appointmentId}`);
+      // 1. 실제 진행 중 약속이 있는 경우에만 미션 상세 페이지로
+      if (nextAppointment) {
+        console.warn('⚠️ [RequireNewUser] 진행 중 약속이 있는 유저 -> /mission으로 리다이렉트');
+        setShouldRedirect(getAppointmentNavigationPath(nextAppointment));
         setIsChecking(false);
         return;
       }
@@ -191,17 +192,18 @@ export const SmartRedirect = () => {
 
             // 미완료 약속 (장소/미션 미선택)은 피드로 이동
             // 피드에서 배너를 통해 이어서 진행 가능
-            const isIncomplete = !nextAppointment.placeName || !nextAppointment.missionTitle;
+            const targetPath = getAppointmentNavigationPath(nextAppointment);
+            const isIncomplete = targetPath !== `/mission/${nextAppointment.id}`;
             if (isIncomplete) {
               console.log('📋 미완료 약속 -> /feed로 이동 (배너에서 이어하기)');
-              setRedirectPath('/feed');
+              setRedirectPath(targetPath);
               setIsLoading(false);
               return;
             }
 
             // 정상적인 약속 (장소+미션 모두 있음) -> 미션 상세 페이지로
             console.log('✅ 완료된 약속 -> /mission으로 이동:', nextAppointment.id);
-            setRedirectPath(`/mission/${nextAppointment.id}`);
+            setRedirectPath(targetPath);
             setIsLoading(false);
             return;
           }

--- a/frontend/src/utils/appointmentNavigation.ts
+++ b/frontend/src/utils/appointmentNavigation.ts
@@ -1,0 +1,20 @@
+import { Appointment, AppointmentStatus } from '../types/appointment';
+
+export const needsAppointmentSelection = (appointment: Appointment): boolean =>
+  appointment.status === AppointmentStatus.UNLOCKED ||
+  (!appointment.missionTitle &&
+    (appointment.status === AppointmentStatus.CREATED ||
+      appointment.status === AppointmentStatus.PENDING ||
+      appointment.status === AppointmentStatus.ACCEPTED));
+
+export const getAppointmentNavigationPath = (appointment: Appointment): string => {
+  if (appointment.status === AppointmentStatus.EXPIRED) {
+    return `/archived/${appointment.id}`;
+  }
+
+  if (needsAppointmentSelection(appointment)) {
+    return `/pick-mission/${appointment.id}`;
+  }
+
+  return `/mission/${appointment.id}`;
+};


### PR DESCRIPTION
- 실제 추천과 시뮬레이션 경로가 같은 규칙을 쓰도록 공통 추천 서비스 계층을 추가하고 정리
- MissionRecommendationSelectionService, PlaceRecommendationScoringService, PlaceScheduleFilterService, RecommendationSupportService, RecommendationTagConflictService, RecommendationPreferenceService, RecommendationEnvironmentService, RecommendationRadiusPolicy 도입
- AppointmentService를 리팩터링해 랜덤 장소 선택을 제거하고 점수 기반 랭킹, 단계적 fallback, 하드 제약 유지, 운영 가능성 필터, 실시간 환경 반영, 공통 helper 재사용으로 정리
- searchRadius를 Appointment에 저장하고 create/update/swap 전 경로에서 동일한 반경 해석 규칙으로 거리 쿼리까지 전달되게 수정
- 실제 추천에 weather, temperature, airQuality, congestion, MBTI, userTags 기반 판단을 반영하고 실내 우선/조용한 장소 선호/개인화 가중치를 강화
- 태그 충돌 규칙을 공통화해 NO_ALCOHOL, NO_SPORTS, INDOOR_ONLY, HATE_WALKING 같은 하드 제약이 실제 추천과 시뮬레이션 모두에서 동일하게 적용되도록 수정
- saved, liked, completed, cancelled 신호를 반영하는 개인화 프로필과 미션/장소 가중치 로직을 추가
- 공연 기간뿐 아니라 operatingTime, closedDays, 운영 상태 문자열까지 반영하는 운영 가능성 필터를 추가하고 제외 사유를 구조화
- SimulationRequest/SimulationResponse와 EnvironmentContext를 확장해 congestion, searchRadius, userTags, userId, 구조화된 stage/reason/selection 정보를 end-to-end로 전달
- SimulationService의 미션 선택을 shuffle 기반에서 실제 추천과 같은 가중치 선택 로직으로 교체하고 단계별 후보 수/탈락 사유/debug trace를 구조화
- DevConsole UI를 확장해 혼잡도/반경/사용자 제약 입력, 구조화된 단계별 결과, 적용 제약, 최종 선택 근거를 확인할 수 있게 개선
- AdminController와 관련 DTO를 갱신해 /api/admin/simulation 응답을 디버깅 가능한 형태로 정비
- PlaceRepository와 도메인/DTO를 정리해 거리 반경, 혼잡도 enum, 장소 세부 운영 정보, 추천 관련 필드를 일관되게 맞춤
- 데이터 수집 및 실시간 환경 활용을 위한 scheduling/config, ingestion DTO, data collection 관련 코드를 보강
- 프론트에서 appointmentNavigation, DevApiControlPanel, appointment/feed/mission/oauth/route guard 흐름을 정리하고 추천 결과 연동을 보강
- AppointmentService 내부의 구버전 랜덤 추천 메서드, 주석 처리된 태그 충돌/카테고리/시간대 helper, 중복 wrapper 등 dead code를 제거해 가독성과 유지보수성을 개선
- mission selection, place scoring, schedule filter, preference, environment context 테스트를 추가해 추천 로직 회귀를 검증